### PR TITLE
Support arbitrary large authority set

### DIFF
--- a/mysticeti-core/src/committee.rs
+++ b/mysticeti-core/src/committee.rs
@@ -41,6 +41,7 @@ impl Committee {
 
         // Ensure all stakes are positive
         assert!(authorities.iter().all(|a| a.stake() > 0));
+        assert!(authorities.len() <= AuthoritySet::MAX_SIZE);
 
         let mut total_stake: Stake = 0;
         for a in authorities.iter() {

--- a/mysticeti-core/src/committee.rs
+++ b/mysticeti-core/src/committee.rs
@@ -41,7 +41,6 @@ impl Committee {
 
         // Ensure all stakes are positive
         assert!(authorities.iter().all(|a| a.stake() > 0));
-        assert!(authorities.len() <= 128); // For now AuthoritySet only supports up to 128 authorities
 
         let mut total_stake: Stake = 0;
         for a in authorities.iter() {
@@ -83,7 +82,7 @@ impl Committee {
     }
 
     pub fn authorities(&self) -> Range<AuthorityIndex> {
-        0u64..(self.authorities.len() as AuthorityIndex)
+        0..(self.authorities.len() as AuthorityIndex)
     }
 
     /// Return own genesis block and other genesis blocks

--- a/mysticeti-core/src/types.rs
+++ b/mysticeti-core/src/types.rs
@@ -23,7 +23,6 @@ use eyre::{bail, ensure};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::mem::size_of;
 use std::ops::Range;
 use std::time::Duration;
 #[cfg(test)]
@@ -92,19 +91,12 @@ pub struct StatementBlock {
     signature: SignatureBytes,
 }
 
-type AuthoritySetElement = u32;
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct AuthoritySet(Vec<AuthoritySetElement>);
-
-impl Default for AuthoritySet {
-    fn default() -> Self {
-        // Represents 128 validators by default.
-        // It is able to grow automatically if needed to deal with unplanned committee growth.
-        // In general, if we know roughly how big our committee is, we should always set a capacity
-        // here so that we don't need to allocate extra memory at runtime.
-        Self(vec![0; 4])
-    }
-}
+type AuthoritySetElementType = u64;
+const ELEMENT_BITS: usize = AuthoritySetElementType::BITS as usize;
+const AUTH_SET_ELEMENT_COUNT: usize = 8;
+// With 8 elements each of 64 bits, we can have up to 512 authorities.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Default)]
+pub struct AuthoritySet([AuthoritySetElementType; AUTH_SET_ELEMENT_COUNT]);
 
 pub type TimestampNs = u128;
 const NANOS_IN_SEC: u128 = Duration::from_secs(1).as_nanos();
@@ -471,17 +463,13 @@ impl fmt::Display for BlockReference {
 }
 
 impl AuthoritySet {
-    const ELEMENT_BITS: u64 = size_of::<AuthoritySetElement>() as u64 * 8;
+    pub const MAX_SIZE: usize = ELEMENT_BITS * AUTH_SET_ELEMENT_COUNT;
 
     #[inline]
     pub fn insert(&mut self, index: AuthorityIndex) -> bool {
-        let byte_index = (index / Self::ELEMENT_BITS) as usize;
-        let bit_index = index % Self::ELEMENT_BITS;
-
-        // Grow the vector if it's not large enough.
-        while self.0.len() <= byte_index {
-            self.0.push(0);
-        }
+        let index = index as usize;
+        let byte_index = index / ELEMENT_BITS;
+        let bit_index = index % ELEMENT_BITS;
 
         let bit = 1 << bit_index;
         if (self.0[byte_index] & bit) != 0 {
@@ -494,9 +482,9 @@ impl AuthoritySet {
 
     pub fn present(&self) -> impl Iterator<Item = AuthorityIndex> + '_ {
         self.0.iter().enumerate().flat_map(|(byte_index, byte)| {
-            (0..Self::ELEMENT_BITS)
+            (0..ELEMENT_BITS)
                 .filter(move |bit_index| (byte & (1 << bit_index)) != 0)
-                .map(move |bit_index| byte_index as AuthorityIndex * Self::ELEMENT_BITS + bit_index)
+                .map(move |bit_index| (byte_index * ELEMENT_BITS + bit_index) as AuthorityIndex)
         })
     }
 
@@ -817,16 +805,10 @@ mod test {
         assert!(a.insert(128));
         assert!(!a.insert(128));
         assert!(a.insert(234));
-        assert!(a.insert(567));
-        assert!(!a.insert(567));
-        assert!(a.insert(1025));
-        assert!(!a.insert(1025));
-        assert!(a.insert(5000));
-        assert!(!a.insert(5000));
-        assert_eq!(
-            a.present().collect::<Vec<_>>(),
-            vec![128, 234, 567, 1025, 5000]
-        );
+        // 511 is the max authority index we could use since we currently only support 512 validators.
+        assert!(a.insert(511));
+        assert!(!a.insert(511));
+        assert_eq!(a.present().collect::<Vec<_>>(), vec![128, 234, 511]);
         a.clear();
         assert!(a.present().collect::<Vec<_>>().is_empty());
     }


### PR DESCRIPTION
This PR changes the authority set from u128 to a Vec<u32>.
By default it's set to support 128 validators. If a larger index is set, it can automatically grow.
While we could also support forcing the constructor to take the size of the committee (since it doesn't change for a given instance), it requires way too many refactoring which I am not sure if it's worth it. 