### PR TITLE
[refactor] allow passing the prometheus Registry down to validator

### DIFF
--- a/mysticeti/src/main.rs
+++ b/mysticeti/src/main.rs
@@ -189,7 +189,7 @@ async fn run(
     binding_metrics_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
 
     // Boot the validator node.
-    let validator = Validator::start(authority, committee, &parameters, private).await?;
+    let validator = Validator::start(authority, committee, &parameters, private, None).await?;
     let (network_result, _metrics_result) = validator.await_completion().await;
     network_result.expect("Validator failed");
     Ok(())
@@ -223,7 +223,7 @@ async fn testbed(committee_size: usize) -> Result<()> {
         let private = PrivateConfig::new_for_benchmarks(&dir, authority);
 
         let validator =
-            Validator::start(authority, committee.clone(), &parameters, private).await?;
+            Validator::start(authority, committee.clone(), &parameters, private, None).await?;
         handles.push(validator.await_completion());
     }
 
@@ -256,7 +256,7 @@ async fn dryrun(authority: AuthorityIndex, committee_size: usize) -> Result<()> 
     }
 
     let private = PrivateConfig::new_for_benchmarks(&dir, authority);
-    Validator::start(authority, committee.clone(), &parameters, private)
+    Validator::start(authority, committee.clone(), &parameters, private, None)
         .await?
         .await_completion()
         .await


### PR DESCRIPTION
In SUI the metrics are exposed and reported by its own prometheus server. To ensure that Mysticeti metrics will be visible as well we just need to allow injecting a pre-created Registry to Mysticeti. In the future the `RegistryService` of SUI could be passed, but no need for now.