### PR TITLE
Refactor CommitObserver to a separate file

### DIFF
--- a/mysticeti-core/src/block_handler.rs
+++ b/mysticeti-core/src/block_handler.rs
@@ -7,22 +7,18 @@ use crate::log::TransactionLog;
 use crate::metrics::UtilizationTimerExt;
 use crate::metrics::UtilizationTimerVecExt;
 use crate::runtime::TimeInstant;
-use crate::syncer::CommitObserver;
+use crate::transactions_generator::TransactionGenerator;
 use crate::types::{
-    AuthorityIndex, BaseStatement, BlockReference, StatementBlock, Transaction, TransactionLocator,
+    AuthorityIndex, BaseStatement, StatementBlock, Transaction, TransactionLocator,
 };
 use crate::{block_store::BlockStore, metrics::Metrics};
 use crate::{
-    committee::{Committee, ProcessedTransactionHandler, QuorumThreshold, TransactionAggregator},
+    committee::{Committee, QuorumThreshold, TransactionAggregator},
     runtime,
-};
-use crate::{
-    consensus::linearizer::{CommittedSubDag, Linearizer},
-    transactions_generator::TransactionGenerator,
 };
 use minibytes::Bytes;
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
@@ -330,155 +326,5 @@ impl BlockHandler for TestBlockHandler {
             .expect("Failed to deserialize transaction aggregator state");
         self.transaction_votes.with_state(&transaction_votes);
         self.last_transaction = last_transaction;
-    }
-}
-
-pub struct TestCommitHandler<H = HashSet<TransactionLocator>> {
-    commit_interpreter: Linearizer,
-    transaction_votes: TransactionAggregator<QuorumThreshold, H>,
-    committee: Arc<Committee>,
-    committed_leaders: Vec<BlockReference>,
-    // committed_dags: Vec<CommittedSubDag>,
-    start_time: TimeInstant,
-    transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
-
-    metrics: Arc<Metrics>,
-    consensus_only: bool,
-}
-
-impl<H: ProcessedTransactionHandler<TransactionLocator> + Default> TestCommitHandler<H> {
-    pub fn new(
-        committee: Arc<Committee>,
-        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
-        metrics: Arc<Metrics>,
-    ) -> Self {
-        Self::new_with_handler(committee, transaction_time, metrics, Default::default())
-    }
-}
-
-impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitHandler<H> {
-    pub fn new_with_handler(
-        committee: Arc<Committee>,
-        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
-        metrics: Arc<Metrics>,
-        handler: H,
-    ) -> Self {
-        let consensus_only = env::var("CONSENSUS_ONLY").is_ok();
-        Self {
-            commit_interpreter: Linearizer::new(),
-            transaction_votes: TransactionAggregator::with_handler(handler),
-            committee,
-            committed_leaders: vec![],
-            // committed_dags: vec![],
-            start_time: TimeInstant::now(),
-            transaction_time,
-
-            metrics,
-            consensus_only,
-        }
-    }
-
-    pub fn committed_leaders(&self) -> &Vec<BlockReference> {
-        &self.committed_leaders
-    }
-
-    /// Note: these metrics are used to compute performance during benchmarks.
-    fn update_metrics(
-        &self,
-        block_creation: Option<&TimeInstant>,
-        current_timestamp: Duration,
-        transaction: &Transaction,
-    ) {
-        // Record inter-block latency.
-        if let Some(instant) = block_creation {
-            let latency = instant.elapsed();
-            self.metrics.transaction_committed_latency.observe(latency);
-            self.metrics
-                .inter_block_latency_s
-                .with_label_values(&["shared"])
-                .observe(latency.as_secs_f64());
-        }
-
-        // Record benchmark start time.
-        let time_from_start = self.start_time.elapsed();
-        let benchmark_duration = self.metrics.benchmark_duration.get();
-        if let Some(delta) = time_from_start.as_secs().checked_sub(benchmark_duration) {
-            self.metrics.benchmark_duration.inc_by(delta);
-        }
-
-        // Record end-to-end latency. The first 8 bytes of the transaction are the timestamp of the
-        // transaction submission.
-        let tx_submission_timestamp = TransactionGenerator::extract_timestamp(transaction);
-        let latency = current_timestamp.saturating_sub(tx_submission_timestamp);
-        let square_latency = latency.as_secs_f64().powf(2.0);
-        self.metrics
-            .latency_s
-            .with_label_values(&["shared"])
-            .observe(latency.as_secs_f64());
-        self.metrics
-            .latency_squared_s
-            .with_label_values(&["shared"])
-            .inc_by(square_latency);
-    }
-}
-
-impl<H: ProcessedTransactionHandler<TransactionLocator> + Send + Sync> CommitObserver
-    for TestCommitHandler<H>
-{
-    fn handle_commit(
-        &mut self,
-        block_store: &BlockStore,
-        committed_leaders: Vec<Data<StatementBlock>>,
-    ) -> Vec<CommittedSubDag> {
-        let current_timestamp = runtime::timestamp_utc();
-
-        let committed = self
-            .commit_interpreter
-            .handle_commit(block_store, committed_leaders);
-        let transaction_time = self.transaction_time.lock();
-        for commit in &committed {
-            self.committed_leaders.push(commit.anchor);
-            for block in &commit.blocks {
-                if !self.consensus_only {
-                    let processed =
-                        self.transaction_votes
-                            .process_block(block, None, &self.committee);
-                    for processed_locator in processed {
-                        if let Some(instant) = transaction_time.get(&processed_locator) {
-                            // todo - batch send data points
-                            self.metrics
-                                .certificate_committed_latency
-                                .observe(instant.elapsed());
-                        }
-                    }
-                }
-                for (locator, transaction) in block.shared_transactions() {
-                    self.update_metrics(
-                        transaction_time.get(&locator),
-                        current_timestamp,
-                        transaction,
-                    );
-                }
-            }
-            // self.committed_dags.push(commit);
-        }
-        self.metrics
-            .commit_handler_pending_certificates
-            .set(self.transaction_votes.len() as i64);
-        committed
-    }
-
-    fn aggregator_state(&self) -> Bytes {
-        self.transaction_votes.state()
-    }
-
-    fn recover_committed(&mut self, committed: HashSet<BlockReference>, state: Option<Bytes>) {
-        assert!(self.commit_interpreter.committed.is_empty());
-        if let Some(state) = state {
-            self.transaction_votes.with_state(&state);
-        } else {
-            assert!(committed.is_empty());
-        }
-        self.commit_interpreter.committed = committed;
     }
 }

--- a/mysticeti-core/src/commit_observer.rs
+++ b/mysticeti-core/src/commit_observer.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::block_store::BlockStore;
+use crate::committee::{
+    Committee, ProcessedTransactionHandler, QuorumThreshold, TransactionAggregator,
+};
+use crate::consensus::linearizer::{CommittedSubDag, Linearizer};
+use crate::data::Data;
+use crate::metrics::Metrics;
+use crate::runtime;
+use crate::runtime::TimeInstant;
+use crate::transactions_generator::TransactionGenerator;
+use crate::types::{BlockReference, StatementBlock, Transaction, TransactionLocator};
+use minibytes::Bytes;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub trait CommitObserver: Send + Sync {
+    fn handle_commit(
+        &mut self,
+        block_store: &BlockStore,
+        committed_leaders: Vec<Data<StatementBlock>>,
+    ) -> Vec<CommittedSubDag>;
+
+    fn aggregator_state(&self) -> Bytes;
+
+    fn recover_committed(&mut self, committed: HashSet<BlockReference>, state: Option<Bytes>);
+}
+
+pub struct TestCommitObserver<H = HashSet<TransactionLocator>> {
+    commit_interpreter: Linearizer,
+    transaction_votes: TransactionAggregator<QuorumThreshold, H>,
+    committee: Arc<Committee>,
+    committed_leaders: Vec<BlockReference>,
+    // committed_dags: Vec<CommittedSubDag>,
+    start_time: TimeInstant,
+    transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+
+    metrics: Arc<Metrics>,
+    consensus_only: bool,
+}
+
+impl<H: ProcessedTransactionHandler<TransactionLocator> + Default> TestCommitObserver<H> {
+    pub fn new(
+        committee: Arc<Committee>,
+        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        Self::new_with_handler(committee, transaction_time, metrics, Default::default())
+    }
+}
+
+impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitObserver<H> {
+    pub fn new_with_handler(
+        committee: Arc<Committee>,
+        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+        metrics: Arc<Metrics>,
+        handler: H,
+    ) -> Self {
+        let consensus_only = env::var("CONSENSUS_ONLY").is_ok();
+        Self {
+            commit_interpreter: Linearizer::new(),
+            transaction_votes: TransactionAggregator::with_handler(handler),
+            committee,
+            committed_leaders: vec![],
+            // committed_dags: vec![],
+            start_time: TimeInstant::now(),
+            transaction_time,
+
+            metrics,
+            consensus_only,
+        }
+    }
+
+    pub fn committed_leaders(&self) -> &Vec<BlockReference> {
+        &self.committed_leaders
+    }
+
+    /// Note: these metrics are used to compute performance during benchmarks.
+    fn update_metrics(
+        &self,
+        block_creation: Option<&TimeInstant>,
+        current_timestamp: Duration,
+        transaction: &Transaction,
+    ) {
+        // Record inter-block latency.
+        if let Some(instant) = block_creation {
+            let latency = instant.elapsed();
+            self.metrics.transaction_committed_latency.observe(latency);
+            self.metrics
+                .inter_block_latency_s
+                .with_label_values(&["shared"])
+                .observe(latency.as_secs_f64());
+        }
+
+        // Record benchmark start time.
+        let time_from_start = self.start_time.elapsed();
+        let benchmark_duration = self.metrics.benchmark_duration.get();
+        if let Some(delta) = time_from_start.as_secs().checked_sub(benchmark_duration) {
+            self.metrics.benchmark_duration.inc_by(delta);
+        }
+
+        // Record end-to-end latency. The first 8 bytes of the transaction are the timestamp of the
+        // transaction submission.
+        let tx_submission_timestamp = TransactionGenerator::extract_timestamp(transaction);
+        let latency = current_timestamp.saturating_sub(tx_submission_timestamp);
+        let square_latency = latency.as_secs_f64().powf(2.0);
+        self.metrics
+            .latency_s
+            .with_label_values(&["shared"])
+            .observe(latency.as_secs_f64());
+        self.metrics
+            .latency_squared_s
+            .with_label_values(&["shared"])
+            .inc_by(square_latency);
+    }
+}
+
+impl<H: ProcessedTransactionHandler<TransactionLocator> + Send + Sync> CommitObserver
+    for TestCommitObserver<H>
+{
+    fn handle_commit(
+        &mut self,
+        block_store: &BlockStore,
+        committed_leaders: Vec<Data<StatementBlock>>,
+    ) -> Vec<CommittedSubDag> {
+        let current_timestamp = runtime::timestamp_utc();
+
+        let committed = self
+            .commit_interpreter
+            .handle_commit(block_store, committed_leaders);
+        let transaction_time = self.transaction_time.lock();
+        for commit in &committed {
+            self.committed_leaders.push(commit.anchor);
+            for block in &commit.blocks {
+                if !self.consensus_only {
+                    let processed =
+                        self.transaction_votes
+                            .process_block(block, None, &self.committee);
+                    for processed_locator in processed {
+                        if let Some(instant) = transaction_time.get(&processed_locator) {
+                            // todo - batch send data points
+                            self.metrics
+                                .certificate_committed_latency
+                                .observe(instant.elapsed());
+                        }
+                    }
+                }
+                for (locator, transaction) in block.shared_transactions() {
+                    self.update_metrics(
+                        transaction_time.get(&locator),
+                        current_timestamp,
+                        transaction,
+                    );
+                }
+            }
+            // self.committed_dags.push(commit);
+        }
+        self.metrics
+            .commit_handler_pending_certificates
+            .set(self.transaction_votes.len() as i64);
+        committed
+    }
+
+    fn aggregator_state(&self) -> Bytes {
+        self.transaction_votes.state()
+    }
+
+    fn recover_committed(&mut self, committed: HashSet<BlockReference>, state: Option<Bytes>) {
+        assert!(self.commit_interpreter.committed.is_empty());
+        if let Some(state) = state {
+            self.transaction_votes.with_state(&state);
+        } else {
+            assert!(committed.is_empty());
+        }
+        self.commit_interpreter.committed = committed;
+    }
+}

--- a/mysticeti-core/src/core_thread/simulated.rs
+++ b/mysticeti-core/src/core_thread/simulated.rs
@@ -4,8 +4,9 @@
 use std::collections::HashSet;
 
 use crate::block_handler::BlockHandler;
+use crate::commit_observer::CommitObserver;
 use crate::data::Data;
-use crate::syncer::{CommitObserver, Syncer, SyncerSignals};
+use crate::syncer::{Syncer, SyncerSignals};
 use crate::types::BlockReference;
 use crate::types::{RoundNumber, StatementBlock};
 use parking_lot::Mutex;

--- a/mysticeti-core/src/core_thread/spawned.rs
+++ b/mysticeti-core/src/core_thread/spawned.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block_handler::BlockHandler;
+use crate::commit_observer::CommitObserver;
 use crate::metrics::{Metrics, UtilizationTimerExt};
-use crate::syncer::{CommitObserver, Syncer, SyncerSignals};
+use crate::syncer::{Syncer, SyncerSignals};
 use crate::types::{RoundNumber, StatementBlock};
 use crate::{data::Data, types::BlockReference};
 use std::sync::Arc;

--- a/mysticeti-core/src/lib.rs
+++ b/mysticeti-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod block_handler;
 mod block_manager;
 mod block_store;
 pub mod block_validator;
+pub mod commit_observer;
 pub mod committee;
 pub mod config;
 pub mod consensus;

--- a/mysticeti-core/src/synchronizer.rs
+++ b/mysticeti-core/src/synchronizer.rs
@@ -7,13 +7,13 @@ use futures::future::join_all;
 use rand::{seq::SliceRandom, thread_rng};
 use tokio::sync::mpsc;
 
+use crate::commit_observer::CommitObserver;
 use crate::{
     block_handler::BlockHandler,
     metrics::Metrics,
     net_sync::{self, NetworkSyncerInner},
     network::NetworkMessage,
     runtime::{sleep, Handle, JoinHandle},
-    syncer::CommitObserver,
     types::{AuthorityIndex, BlockReference, RoundNumber},
 };
 

--- a/mysticeti-core/src/validator.rs
+++ b/mysticeti-core/src/validator.rs
@@ -12,11 +12,12 @@ use ::prometheus::Registry;
 use eyre::{eyre, Context, Result};
 
 use crate::block_validator::AcceptAllValidator;
+use crate::commit_observer::TestCommitObserver;
 use crate::crypto::Signer;
 use crate::runtime::Handle;
 use crate::wal::walf;
 use crate::{
-    block_handler::{BenchmarkFastPathBlockHandler, TestCommitHandler},
+    block_handler::BenchmarkFastPathBlockHandler,
     committee::Committee,
     config::{Parameters, PrivateConfig},
     core::Core,
@@ -33,7 +34,7 @@ use crate::{core::CoreOptions, transactions_generator::TransactionGenerator};
 
 pub struct Validator {
     network_synchronizer:
-        NetworkSyncer<BenchmarkFastPathBlockHandler, TestCommitHandler<TransactionLog>>,
+        NetworkSyncer<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>>,
     metrics_handle: JoinHandle<Result<(), hyper::Error>>,
 }
 
@@ -127,7 +128,7 @@ impl Validator {
         let committed_transaction_log =
             TransactionLog::start(config.storage().committed_transactions_log())
                 .expect("Failed to open committed transaction log for write");
-        let commit_handler = TestCommitHandler::new_with_handler(
+        let commit_handler = TestCommitObserver::new_with_handler(
             committee.clone(),
             block_handler.transaction_time.clone(),
             metrics.clone(),


### PR DESCRIPTION
This PR moves the CommitObserver trait to a dedicated file, along with the TestCommitHandler (renamed to TestCommitObserver).
No functionality is changed.