### PR TITLE
Add a simple commit observer

### DIFF
--- a/mysticeti-core/src/consensus/linearizer.rs
+++ b/mysticeti-core/src/consensus/linearizer.rs
@@ -12,6 +12,7 @@ use std::fmt::{Display, Formatter};
 
 /// The output of consensus is an ordered list of [`CommittedSubDag`]. The application can arbitrarily
 /// sort the blocks within each sub-dag (but using a deterministic algorithm).
+#[derive(Clone)]
 pub struct CommittedSubDag {
     /// A reference to the anchor of the sub-dag
     pub anchor: BlockReference,


### PR DESCRIPTION
Add a simple commit observer that's not for testing and could be used for production, at least as a starting point.