### PR TITLE
fix shutdown process of validator 

### DIFF
--- a/mysticeti-core/src/metrics.rs
+++ b/mysticeti-core/src/metrics.rs
@@ -461,8 +461,6 @@ impl MetricReporter {
 
         self.connection_latency.clear_receive_all();
     }
-
-    // todo - this task never stops
     async fn run(mut self, mut stop: tokio::sync::mpsc::Receiver<()>) {
         const REPORT_INTERVAL: Duration = Duration::from_secs(60);
         let mut deadline = Instant::now();

--- a/mysticeti-core/src/net_sync.rs
+++ b/mysticeti-core/src/net_sync.rs
@@ -165,6 +165,7 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
             .unwrap_or_else(|_| panic!("Failed to drop all connections"))
             .shutdown()
             .await;
+        network.shutdown().await;
     }
 
     async fn connection_task(

--- a/mysticeti-core/src/network.rs
+++ b/mysticeti-core/src/network.rs
@@ -137,10 +137,10 @@ impl Network {
 
     pub async fn shutdown(mut self) {
         if let Some(stop) = self.stop.take() {
-            let _ = stop.send(()).await;
+            stop.send(()).await.ok();
         }
         if let Some(handle) = self.server_handle.take() {
-            let _ = handle.await;
+            handle.await.ok();
         }
     }
 }

--- a/mysticeti-core/src/network.rs
+++ b/mysticeti-core/src/network.rs
@@ -25,6 +25,8 @@ use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::runtime::Handle;
 use tokio::select;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::Receiver;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 const PING_INTERVAL: Duration = Duration::from_secs(30);
@@ -41,6 +43,8 @@ pub enum NetworkMessage {
 
 pub struct Network {
     connection_receiver: mpsc::Receiver<Connection>,
+    stop: Option<mpsc::Sender<()>>,
+    server_handle: Option<JoinHandle<()>>,
 }
 
 pub struct Connection {
@@ -54,6 +58,8 @@ impl Network {
     pub(crate) fn new_from_raw(connection_receiver: mpsc::Receiver<Connection>) -> Self {
         Self {
             connection_receiver,
+            stop: None,
+            server_handle: None,
         }
     }
 
@@ -113,15 +119,28 @@ impl Network {
                 .run(receiver),
             );
         }
-        handle.spawn(
+        let (stop, rx_stop) = tokio::sync::mpsc::channel(1);
+        let server_handle = handle.spawn(async {
             Server {
                 server,
                 worker_senders,
             }
-            .run(),
-        );
+            .run(rx_stop)
+            .await
+        });
         Self {
             connection_receiver,
+            stop: Some(stop),
+            server_handle: Some(server_handle),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(()).await;
+        }
+        if let Some(handle) = self.server_handle.take() {
+            let _ = handle.await;
         }
     }
 }
@@ -132,14 +151,22 @@ struct Server {
 }
 
 impl Server {
-    async fn run(self) {
+    async fn run(self, mut stop: Receiver<()>) {
         loop {
-            let (socket, remote_peer) = self.server.accept().await.expect("Accept failed");
-            let remote_peer = remote_to_local_port(remote_peer);
-            if let Some(sender) = self.worker_senders.get(&remote_peer) {
-                sender.send(socket).ok();
-            } else {
-                tracing::warn!("Dropping connection from unknown peer {remote_peer}");
+            tokio::select! {
+                result = self.server.accept() => {
+                    let (socket, remote_peer) = result.expect("accept failed");
+                    let remote_peer = remote_to_local_port(remote_peer);
+                    if let Some(sender) = self.worker_senders.get(&remote_peer) {
+                        sender.send(socket).ok();
+                    } else {
+                        tracing::warn!("Dropping connection from unknown peer {remote_peer}");
+                    }
+                }
+                _ = stop.recv() => {
+                    println!("Shutting down network");
+                    return;
+                }
             }
         }
     }

--- a/mysticeti-core/src/network.rs
+++ b/mysticeti-core/src/network.rs
@@ -164,7 +164,7 @@ impl Server {
                     }
                 }
                 _ = stop.recv() => {
-                    println!("Shutting down network");
+                    tracing::info!("Shutting down network");
                     return;
                 }
             }

--- a/mysticeti-core/src/prometheus.rs
+++ b/mysticeti-core/src/prometheus.rs
@@ -23,8 +23,8 @@ impl PrometheusServerHandle {
         Self { stop, handle }
     }
     pub async fn shutdown(self) {
-        let _ = self.stop.send(());
-        let _ = self.handle.await;
+        self.stop.send(()).ok();
+        self.handle.await.ok();
     }
 }
 

--- a/mysticeti-core/src/prometheus.rs
+++ b/mysticeti-core/src/prometheus.rs
@@ -4,22 +4,48 @@
 use axum::{http::StatusCode, routing::get, Extension, Router, Server};
 use prometheus::{Registry, TextEncoder};
 use std::net::SocketAddr;
+use tokio::sync::oneshot::{channel, Sender};
 
 use crate::runtime::{Handle, JoinHandle};
 
 pub const METRICS_ROUTE: &str = "/metrics";
 
-pub fn start_prometheus_server(
-    address: SocketAddr,
-    registry: &Registry,
-) -> JoinHandle<Result<(), hyper::Error>> {
+pub struct PrometheusServerHandle {
+    pub handle: JoinHandle<Result<(), hyper::Error>>,
+    stop: Sender<()>,
+}
+
+impl PrometheusServerHandle {
+    pub fn noop() -> PrometheusServerHandle {
+        let (stop, _rx_stop) = channel();
+        let handle = Handle::current().spawn(async { Ok(()) });
+
+        Self { stop, handle }
+    }
+    pub async fn shutdown(self) {
+        let _ = self.stop.send(());
+        let _ = self.handle.await;
+    }
+}
+
+pub fn start_prometheus_server(address: SocketAddr, registry: &Registry) -> PrometheusServerHandle {
     let app = Router::new()
         .route(METRICS_ROUTE, get(metrics))
         .layer(Extension(registry.clone()));
 
+    let (stop, rx_stop) = channel();
+
     tracing::info!("Prometheus server booted on {address}");
-    Handle::current()
-        .spawn(async move { Server::bind(&address).serve(app.into_make_service()).await })
+    let handle = Handle::current().spawn(async move {
+        Server::bind(&address)
+            .serve(app.into_make_service())
+            .with_graceful_shutdown(async {
+                rx_stop.await.ok();
+            })
+            .await
+    });
+
+    PrometheusServerHandle { handle, stop }
 }
 
 async fn metrics(registry: Extension<Registry>) -> (StatusCode, String) {

--- a/mysticeti-core/src/synchronizer.rs
+++ b/mysticeti-core/src/synchronizer.rs
@@ -237,7 +237,6 @@ impl BlockFetcher {
     }
 
     pub async fn shutdown(self) {
-        println!("Synchronizer shutting down...");
         self.handle.abort();
         self.handle.await.ok();
     }

--- a/mysticeti-core/src/synchronizer.rs
+++ b/mysticeti-core/src/synchronizer.rs
@@ -237,6 +237,7 @@ impl BlockFetcher {
     }
 
     pub async fn shutdown(self) {
+        println!("Synchronizer shutting down...");
         self.handle.abort();
         self.handle.await.ok();
     }

--- a/mysticeti-core/src/transactions_generator.rs
+++ b/mysticeti-core/src/transactions_generator.rs
@@ -4,13 +4,27 @@
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::{channel, Receiver};
 
+use crate::runtime::JoinHandle;
 use crate::{
     crypto::AsBytes,
     runtime,
     runtime::timestamp_utc,
     types::{AuthorityIndex, Transaction},
 };
+
+pub struct TransactionGeneratorHandle {
+    stop: mpsc::Sender<()>,
+    handle: JoinHandle<()>,
+}
+
+impl TransactionGeneratorHandle {
+    pub async fn shutdown(self) {
+        let _ = self.stop.send(()).await;
+        let _ = self.handle.await;
+    }
+}
 
 pub struct TransactionGenerator {
     sender: mpsc::Sender<Vec<Transaction>>,
@@ -30,9 +44,10 @@ impl TransactionGenerator {
         transactions_per_second: usize,
         transaction_size: usize,
         initial_delay: Duration,
-    ) {
+    ) -> TransactionGeneratorHandle {
         assert!(transaction_size >= 8 + 8); // 8 bytes timestamp + 8 bytes random
-        runtime::Handle::current().spawn(
+        let (stop, rx_stop) = channel(1);
+        let handle = runtime::Handle::current().spawn(
             Self {
                 sender,
                 rng: StdRng::seed_from_u64(seed),
@@ -40,11 +55,13 @@ impl TransactionGenerator {
                 transaction_size,
                 initial_delay,
             }
-            .run(),
+            .run(rx_stop),
         );
+
+        TransactionGeneratorHandle { stop, handle }
     }
 
-    pub async fn run(mut self) {
+    pub async fn run(mut self, mut rx_stop: Receiver<()>) {
         let transactions_per_100ms = (self.transactions_per_second + 9) / 10;
 
         let mut counter = 0;
@@ -54,25 +71,31 @@ impl TransactionGenerator {
         let mut interval = runtime::TimeInterval::new(Self::TARGET_BLOCK_INTERVAL);
         runtime::sleep(self.initial_delay).await;
         loop {
-            interval.tick().await;
+            tokio::select! {
+                _ = interval.tick() => {
+                    let mut block = Vec::with_capacity(transactions_per_100ms);
+                    let timestamp = (timestamp_utc().as_millis() as u64).to_le_bytes();
 
-            let mut block = Vec::with_capacity(transactions_per_100ms);
-            let timestamp = (timestamp_utc().as_millis() as u64).to_le_bytes();
+                    for _ in 0..transactions_per_100ms {
+                        random += counter;
 
-            for _ in 0..transactions_per_100ms {
-                random += counter;
+                        let mut transaction = Vec::with_capacity(self.transaction_size);
+                        transaction.extend_from_slice(&timestamp); // 8 bytes
+                        transaction.extend_from_slice(&random.to_le_bytes()); // 8 bytes
+                        transaction.extend_from_slice(&zeros[..]);
 
-                let mut transaction = Vec::with_capacity(self.transaction_size);
-                transaction.extend_from_slice(&timestamp); // 8 bytes
-                transaction.extend_from_slice(&random.to_le_bytes()); // 8 bytes
-                transaction.extend_from_slice(&zeros[..]);
+                        block.push(Transaction::new(transaction));
+                        counter += 1;
+                    }
 
-                block.push(Transaction::new(transaction));
-                counter += 1;
-            }
-
-            if self.sender.send(block).await.is_err() {
-                break;
+                    if self.sender.send(block).await.is_err() {
+                        break;
+                    }
+                },
+                _ = rx_stop.recv() => {
+                    tracing::info!("Shutting down transactions generator");
+                    return;
+                }
             }
         }
     }

--- a/mysticeti-core/src/transactions_generator.rs
+++ b/mysticeti-core/src/transactions_generator.rs
@@ -21,8 +21,8 @@ pub struct TransactionGeneratorHandle {
 
 impl TransactionGeneratorHandle {
     pub async fn shutdown(self) {
-        let _ = self.stop.send(()).await;
-        let _ = self.handle.await;
+        self.stop.send(()).await.ok();
+        self.handle.await.ok();
     }
 }
 

--- a/mysticeti-core/src/validator.rs
+++ b/mysticeti-core/src/validator.rs
@@ -35,7 +35,8 @@ use crate::{block_store::BlockStore, log::TransactionLog};
 use crate::{core::CoreOptions, transactions_generator::TransactionGenerator};
 
 pub struct Validator {
-    network_synchronizer: NetworkSyncer<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>>,
+    network_synchronizer:
+        NetworkSyncer<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>>,
     metrics_handle: PrometheusServerHandle,
     reporter_handle: MetricReporterHandle,
     transaction_generator_handle: TransactionGeneratorHandle,


### PR DESCRIPTION
After wiring Mysticeti to SUI it looks like it wasn't able to properly shutdown giving us errors when trying to bootstrap again the validator node like:
```
Failed to bind to local socket: Os { code: 48, kind: AddrInUse, message: "Address already in use" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

which basically raised suspicions of networking not properly shutting down and potentially a few other components too.

By using a simple test that starts and shutdown a validator not and using tokio-console we could see that some tasks were not terminating (amongst them network as well occupying the current port)

<img width="1247" alt="Screenshot 2023-11-04 at 01 31 03" src="https://github.com/MystenLabs/mysticeti/assets/17335598/9ead8658-7d11-4a57-a9e9-8d2a8d451543">

after introducing explicit handling on propagating shutdown signals to the task components after shutting down the validator we can see that none of the tasks is running any more:

<img width="1238" alt="Screenshot 2023-11-04 at 01 25 06" src="https://github.com/MystenLabs/mysticeti/assets/17335598/77e87e9d-d15a-4df4-be2c-f56e4ae2f5ad">

a test has been introduced for this case which is successfully passing after the introduced changes. Running the same test in main fails with a `Failed to bind to local socket: Os { code: 48, kind: AddrInUse, message: "Address already in use" }` error.
