### PR TITLE
Initialise validator for production with SimpleBlockHandler, SimpleCommitObserver & wire consumer properties

### DIFF
--- a/mysticeti-core/src/commit_observer.rs
+++ b/mysticeti-core/src/commit_observer.rs
@@ -12,9 +12,9 @@ use crate::runtime;
 use crate::runtime::TimeInstant;
 use crate::transactions_generator::TransactionGenerator;
 use crate::types::{BlockReference, StatementBlock, Transaction, TransactionLocator};
+use crate::validator::TransactionTimeMap;
 use minibytes::Bytes;
-use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
@@ -46,7 +46,7 @@ pub struct TestCommitObserver<H = HashSet<TransactionLocator>> {
     committed_leaders: Vec<BlockReference>,
     // committed_dags: Vec<CommittedSubDag>,
     start_time: TimeInstant,
-    transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+    transaction_time: TransactionTimeMap,
 
     metrics: Arc<Metrics>,
     consensus_only: bool,
@@ -56,7 +56,7 @@ impl<H: ProcessedTransactionHandler<TransactionLocator> + Default> TestCommitObs
     pub fn new_for_testing(
         block_store: BlockStore,
         committee: Arc<Committee>,
-        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+        transaction_time: TransactionTimeMap,
         metrics: Arc<Metrics>,
     ) -> Self {
         Self::new(
@@ -74,7 +74,7 @@ impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitObserver<H> {
     pub fn new(
         block_store: BlockStore,
         committee: Arc<Committee>,
-        transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
+        transaction_time: TransactionTimeMap,
         metrics: Arc<Metrics>,
         handler: H,
         recovered_state: CommitObserverRecoveredState,

--- a/mysticeti-core/src/lib.rs
+++ b/mysticeti-core/src/lib.rs
@@ -48,5 +48,7 @@ pub mod validator;
 mod wal;
 
 // re-export
+pub use crate::block_handler::SimpleBlockHandler;
 pub use crate::crypto::{dummy_signer, PublicKey, Signer};
+pub use crate::validator::CommitConsumer;
 pub use minibytes;

--- a/mysticeti-core/src/validator.rs
+++ b/mysticeti-core/src/validator.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::time::Duration;
 use std::{
     env,
@@ -10,14 +11,24 @@ use std::{
 
 use ::prometheus::Registry;
 use eyre::{eyre, Context, Result};
+use parking_lot::Mutex;
+use tokio::sync::mpsc::UnboundedSender;
 
+use crate::block_handler::{BlockHandler, SimpleBlockHandler};
 use crate::block_validator::AcceptAllValidator;
-use crate::commit_observer::TestCommitObserver;
+use crate::commit_observer::{
+    CommitObserver, CommitObserverRecoveredState, SimpleCommitObserver, TestCommitObserver,
+};
+use crate::consensus::linearizer::CommittedSubDag;
 use crate::crypto::Signer;
+use crate::metrics::MetricReporter;
 use crate::metrics::MetricReporterHandle;
 use crate::prometheus::PrometheusServerHandle;
+use crate::runtime::TimeInstant;
+use crate::state::CoreRecoveredState;
 use crate::transactions_generator::TransactionGeneratorHandle;
-use crate::wal::walf;
+use crate::types::TransactionLocator;
+use crate::wal::{walf, WalWriter};
 use crate::{
     block_handler::BenchmarkFastPathBlockHandler,
     committee::Committee,
@@ -34,74 +45,61 @@ use crate::{
 use crate::{block_store::BlockStore, log::TransactionLog};
 use crate::{core::CoreOptions, transactions_generator::TransactionGenerator};
 
-pub struct Validator {
-    network_synchronizer:
-        NetworkSyncer<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>>,
-    metrics_handle: PrometheusServerHandle,
-    reporter_handle: MetricReporterHandle,
-    transaction_generator_handle: TransactionGeneratorHandle,
+pub(crate) type TransactionTimeMap = Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>;
+
+pub struct CommitConsumer {
+    // A sender to forward the committed sub dags to
+    sender: UnboundedSender<CommittedSubDag>,
+    // The last commit height that the consumer has consumed up to. This is useful for crash/recovery
+    // so mysticeti can replay the commits from `last_sent_height + 1`.
+    last_sent_height: u64,
 }
 
-impl Validator {
-    pub async fn start(
+impl CommitConsumer {
+    #[allow(dead_code)]
+    pub fn new(sender: UnboundedSender<CommittedSubDag>, last_sent_height: u64) -> Self {
+        Self {
+            sender,
+            last_sent_height,
+        }
+    }
+}
+
+pub struct Validator<
+    B: BlockHandler + 'static = BenchmarkFastPathBlockHandler,
+    C: CommitObserver + 'static = TestCommitObserver<TransactionLog>,
+> {
+    network_synchronizer: NetworkSyncer<B, C>,
+    metrics_handle: PrometheusServerHandle,
+    reporter_handle: MetricReporterHandle,
+    transaction_generator_handle: Option<TransactionGeneratorHandle>,
+}
+
+impl Validator<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>> {
+    // Method to be used when need to start a validator but for benchmarking/testing purposes. It is
+    // initialising the BenchmarkFastPathBlockHandler.
+    pub async fn start_benchmarking(
         authority: AuthorityIndex,
         committee: Arc<Committee>,
         parameters: &Parameters,
         config: PrivateConfig,
-        registry: Option<Registry>,
         signer: Signer,
-    ) -> Result<Self> {
-        let network_address = parameters
-            .network_address(authority)
-            .ok_or(eyre!("No network address for authority {authority}"))
-            .wrap_err("Unknown authority")?;
-        let mut binding_network_address = network_address;
-        binding_network_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-
-        // Boot the prometheus server only when a registry is not passed in. If a registry is passed in
-        // we assume that an upstream component is responsible for exposing the metrics.
-        let (registry, metrics_handle) = if let Some(registry) = registry {
-            (registry, PrometheusServerHandle::noop())
-        } else {
-            let registry = Registry::new();
-
-            let metrics_address = parameters
-                .metrics_address(authority)
-                .ok_or(eyre!("No metrics address for authority {authority}"))
-                .wrap_err("Unknown authority")?;
-            let mut binding_metrics_address = metrics_address;
-            binding_metrics_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-
-            let metrics_handle =
-                prometheus::start_prometheus_server(binding_metrics_address, &registry);
-
-            tracing::info!("Validator {authority} exposing metrics on {metrics_address}");
-
-            (registry, metrics_handle)
-        };
-
-        let (metrics, reporter) = Metrics::new(&registry, Some(&committee));
+    ) -> Result<Validator<BenchmarkFastPathBlockHandler, TestCommitObserver<TransactionLog>>> {
+        let (metrics, reporter, metrics_handle) =
+            Self::init_metrics(authority, committee.clone(), parameters, None)?;
+        let (core_recovered, commit_observer_recovered, wal_writer) =
+            Self::init_storage(authority, committee.clone(), &config, metrics.clone());
         let reporter_handle = reporter.start();
 
-        // Open the block store.
-        let wal_file =
-            wal::open_file_for_wal(config.storage().wal()).expect("Failed to open wal file");
-        let (wal_writer, wal_reader) = walf(wal_file).expect("Failed to open wal");
-        let (core_recovered, commit_observer_recovered) = BlockStore::open(
-            authority,
-            Arc::new(wal_reader),
-            &wal_writer,
-            metrics.clone(),
-            &committee,
-        );
-
         // Boot the validator node.
+        let transaction_time: TransactionTimeMap = Arc::new(Mutex::new(HashMap::new()));
         let (block_handler, block_sender) = BenchmarkFastPathBlockHandler::new(
             committee.clone(),
             authority,
             config.storage(),
             core_recovered.block_store.clone(),
             metrics.clone(),
+            transaction_time.clone(),
         );
         let tps = env::var("TPS");
         let tps = tps.map(|t| t.parse::<usize>().expect("Failed to parse TPS variable"));
@@ -129,17 +127,108 @@ impl Validator {
             transaction_size,
             initial_delay,
         );
+
+        // Boot the validator node.
         let committed_transaction_log =
             TransactionLog::start(config.storage().committed_transactions_log())
                 .expect("Failed to open committed transaction log for write");
         let commit_observer = TestCommitObserver::new(
             core_recovered.block_store.clone(),
             committee.clone(),
-            block_handler.transaction_time.clone(),
+            transaction_time,
             metrics.clone(),
             committed_transaction_log,
             commit_observer_recovered,
         );
+
+        Validator::start_internal(
+            authority,
+            committee,
+            parameters,
+            signer,
+            metrics,
+            metrics_handle,
+            reporter_handle,
+            Some(transaction_generator_handle),
+            core_recovered,
+            wal_writer,
+            block_handler,
+            commit_observer,
+        )
+        .await
+    }
+}
+
+impl Validator<SimpleBlockHandler> {
+    pub async fn start_production(
+        authority: AuthorityIndex,
+        committee: Arc<Committee>,
+        parameters: &Parameters,
+        config: PrivateConfig,
+        registry: Registry,
+        signer: Signer,
+        consumer: CommitConsumer,
+    ) -> Result<(
+        Validator<SimpleBlockHandler, SimpleCommitObserver>,
+        tokio::sync::mpsc::Sender<(Vec<u8>, tokio::sync::oneshot::Sender<()>)>,
+    )> {
+        let (metrics, reporter, metrics_handle) =
+            Self::init_metrics(authority, committee.clone(), parameters, Some(registry))?;
+        let (core_recovered, commit_observer_recovered, wal_writer) =
+            Self::init_storage(authority, committee.clone(), &config, metrics.clone());
+        let reporter_handle = reporter.start();
+        let (block_handler, tx_sender) = SimpleBlockHandler::new();
+
+        let commit_observer = SimpleCommitObserver::new(
+            core_recovered.block_store.clone(),
+            consumer.sender,
+            consumer.last_sent_height,
+            commit_observer_recovered,
+        );
+
+        let validator = Validator::start_internal(
+            authority,
+            committee,
+            parameters,
+            signer,
+            metrics,
+            metrics_handle,
+            reporter_handle,
+            None,
+            core_recovered,
+            wal_writer,
+            block_handler,
+            commit_observer,
+        )
+        .await?;
+
+        Ok((validator, tx_sender))
+    }
+}
+
+impl<B: BlockHandler + 'static, C: CommitObserver + 'static> Validator<B, C> {
+    #[allow(clippy::too_many_arguments)]
+    async fn start_internal(
+        authority: AuthorityIndex,
+        committee: Arc<Committee>,
+        parameters: &Parameters,
+        signer: Signer,
+        metrics: Arc<Metrics>,
+        metrics_handle: PrometheusServerHandle,
+        reporter_handle: MetricReporterHandle,
+        transaction_generator_handle: Option<TransactionGeneratorHandle>,
+        core_recovered: CoreRecoveredState,
+        wal_writer: WalWriter,
+        block_handler: B,
+        commit_observer: C,
+    ) -> Result<Self> {
+        let network_address = parameters
+            .network_address(authority)
+            .ok_or(eyre!("No network address for authority {authority}"))
+            .wrap_err("Unknown authority")?;
+        let mut binding_network_address = network_address;
+        binding_network_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
         let core = Core::open(
             block_handler,
             authority,
@@ -195,7 +284,61 @@ impl Validator {
         self.network_synchronizer.shutdown().await;
         self.reporter_handle.shutdown().await;
         self.metrics_handle.shutdown().await;
-        self.transaction_generator_handle.shutdown().await;
+        if let Some(handle) = self.transaction_generator_handle {
+            handle.shutdown().await;
+        }
+    }
+
+    fn init_metrics(
+        authority: AuthorityIndex,
+        committee: Arc<Committee>,
+        parameters: &Parameters,
+        registry: Option<Registry>,
+    ) -> Result<(Arc<Metrics>, MetricReporter, PrometheusServerHandle)> {
+        // Boot the prometheus server only when a registry is not passed in. If a registry is passed in
+        // we assume that an upstream component is responsible for exposing the metrics.
+        let (registry, metrics_handle) = if let Some(registry) = registry {
+            (registry, PrometheusServerHandle::noop())
+        } else {
+            let registry = Registry::new();
+
+            let metrics_address = parameters
+                .metrics_address(authority)
+                .ok_or(eyre!("No metrics address for authority {authority}"))
+                .wrap_err("Unknown authority")?;
+            let mut binding_metrics_address = metrics_address;
+            binding_metrics_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+            let metrics_handle =
+                prometheus::start_prometheus_server(binding_metrics_address, &registry);
+
+            tracing::info!("Validator {authority} exposing metrics on {metrics_address}");
+
+            (registry, metrics_handle)
+        };
+
+        let (metrics, reporter) = Metrics::new(&registry, Some(&committee));
+        Ok((metrics, reporter, metrics_handle))
+    }
+
+    fn init_storage(
+        authority: AuthorityIndex,
+        committee: Arc<Committee>,
+        config: &PrivateConfig,
+        metrics: Arc<Metrics>,
+    ) -> (CoreRecoveredState, CommitObserverRecoveredState, WalWriter) {
+        // Open the block store.
+        let wal_file =
+            wal::open_file_for_wal(config.storage().wal()).expect("Failed to open wal file");
+        let (wal_writer, wal_reader) = walf(wal_file).expect("Failed to open wal");
+        let (core_recovered, commit_observer_recovered) = BlockStore::open(
+            authority,
+            Arc::new(wal_reader),
+            &wal_writer,
+            metrics.clone(),
+            &committee,
+        );
+        (core_recovered, commit_observer_recovered, wal_writer)
     }
 }
 
@@ -256,12 +399,11 @@ mod smoke_tests {
             let authority = i as AuthorityIndex;
             let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
 
-            let validator = Validator::start(
+            let validator = Validator::start_benchmarking(
                 authority,
                 committee.clone(),
                 &parameters,
                 private,
-                None,
                 dummy_signer(),
             )
             .await
@@ -298,12 +440,11 @@ mod smoke_tests {
             let authority = i as AuthorityIndex;
             let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
 
-            let validator = Validator::start(
+            let validator = Validator::start_benchmarking(
                 authority,
                 committee.clone(),
                 &parameters,
                 private,
-                None,
                 dummy_signer(),
             )
             .await
@@ -326,12 +467,11 @@ mod smoke_tests {
         // Boot the last validator.
         let authority = 0 as AuthorityIndex;
         let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
-        let validator = Validator::start(
+        let validator = Validator::start_benchmarking(
             authority,
             committee.clone(),
             &parameters,
             private,
-            None,
             dummy_signer(),
         )
         .await
@@ -366,12 +506,11 @@ mod smoke_tests {
             let authority = i as AuthorityIndex;
             let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
 
-            let validator = Validator::start(
+            let validator = Validator::start_benchmarking(
                 authority,
                 committee.clone(),
                 &parameters,
                 private,
-                None,
                 dummy_signer(),
             )
             .await
@@ -407,12 +546,11 @@ mod smoke_tests {
             let authority = i as AuthorityIndex;
             let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
 
-            let validator = Validator::start(
+            let validator = Validator::start_benchmarking(
                 authority,
                 committee.clone(),
                 &parameters,
                 private,
-                None,
                 dummy_signer(),
             )
             .await
@@ -444,12 +582,11 @@ mod smoke_tests {
             let authority = i as AuthorityIndex;
             let private = PrivateConfig::new_for_benchmarks(tempdir.as_ref(), authority);
 
-            let validator = Validator::start(
+            let validator = Validator::start_benchmarking(
                 authority,
                 committee.clone(),
                 &parameters,
                 private,
-                None,
                 dummy_signer(),
             )
             .await

--- a/mysticeti/src/main.rs
+++ b/mysticeti/src/main.rs
@@ -190,15 +190,9 @@ async fn run(
     binding_metrics_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
 
     // Boot the validator node.
-    let validator = Validator::start(
-        authority,
-        committee,
-        &parameters,
-        private,
-        None,
-        dummy_signer(),
-    )
-    .await?;
+    let validator =
+        Validator::start_benchmarking(authority, committee, &parameters, private, dummy_signer())
+            .await?;
     let (network_result, _metrics_result) = validator.await_completion().await;
     network_result.expect("Validator failed");
     Ok(())
@@ -231,12 +225,11 @@ async fn testbed(committee_size: usize) -> Result<()> {
         let authority = i as AuthorityIndex;
         let private = PrivateConfig::new_for_benchmarks(&dir, authority);
 
-        let validator = Validator::start(
+        let validator = Validator::start_benchmarking(
             authority,
             committee.clone(),
             &parameters,
             private,
-            None,
             dummy_signer(),
         )
         .await?;
@@ -272,12 +265,11 @@ async fn dryrun(authority: AuthorityIndex, committee_size: usize) -> Result<()> 
     }
 
     let private = PrivateConfig::new_for_benchmarks(&dir, authority);
-    Validator::start(
+    Validator::start_benchmarking(
         authority,
         committee.clone(),
         &parameters,
         private,
-        None,
         dummy_signer(),
     )
     .await?


### PR DESCRIPTION
After a few iterations I found the most straightforward way to inject a BlockHandler to the `Validator::start` method - as a trait should be accepted  - to now have a method `Validator::start_benchmarking` to initialise a Validator with the `BenchmarkFastPathBlockHandler` block handler.

The whole complexity did arise from the fact that to initialise `BenchmarkFastPathBlockHandler` a few components that gets initialised during the `start` method should be passed in, which complicate things. 

I've ended up introducing three public methods:
* `Validator::start_benchmarking` which explicitly initialises a validator for testing/benchmarking that is being used from the codebase
* `Validator::start_production` which explicitly initialises a validator which is using the `SimpleBlockHandler` and should be used for the production purposes
* `Validator::start` where another custom `BlockHandler` can be passed in

Ultimately in SUI we should just use the `Validator::start_production` which should be straightforward . The PR is also moving the [SimpleBlockHandler](https://github.com/MystenLabs/sui/pull/14647/files) from SUI to Mysticeti . Although I also believed that it would be a good fit in SUI, it turns out that things are simpler if it just lives for now in Mysticeti.

Note: similarly we'll be able to inject the consensus handler to the validator