### PR TITLE
Introduce CommitSubDag::height

### DIFF
--- a/mysticeti-core/src/block_store.rs
+++ b/mysticeti-core/src/block_store.rs
@@ -524,10 +524,15 @@ impl OwnBlockData {
 }
 
 #[derive(Serialize, Deserialize)]
+/// CommitData is a serializable version of the CommittedSubDag.
+/// Main difference is that CommittedSubDag has Data<Block> and can be used by downstream consensus handler.
+/// CommitData instead only stores BlockReference, and can be written to the wal.
 pub struct CommitData {
     pub leader: BlockReference,
     // All committed blocks, including the leader
     pub sub_dag: Vec<BlockReference>,
+    // Height of the commit, corresponds to CommittedSubDag::height
+    pub height: u64,
 }
 
 impl From<&CommittedSubDag> for CommitData {
@@ -536,6 +541,7 @@ impl From<&CommittedSubDag> for CommitData {
         Self {
             leader: value.anchor,
             sub_dag,
+            height: value.height,
         }
     }
 }

--- a/mysticeti-core/src/net_sync.rs
+++ b/mysticeti-core/src/net_sync.rs
@@ -56,8 +56,8 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
         let handle = Handle::current();
         let notify = Arc::new(Notify::new());
         // todo - ugly, probably need to merge syncer and core
-        let (committed, state) = core.take_recovered_committed_blocks();
-        commit_observer.recover_committed(committed, state);
+        let commit_observer_state = core.take_recovered_committed_blocks();
+        commit_observer.recover_committed(commit_observer_state);
         let committee = core.committee().clone();
         let wal_syncer = core.wal_syncer();
         let block_store = core.block_store().clone();

--- a/mysticeti-core/src/state.rs
+++ b/mysticeti-core/src/state.rs
@@ -15,6 +15,7 @@ pub struct RecoveredState {
 
     pub last_committed_leader: Option<BlockReference>,
     pub committed_blocks: HashSet<BlockReference>,
+    pub last_committed_height: u64,
     pub committed_state: Option<Bytes>,
 }
 
@@ -27,6 +28,7 @@ pub struct RecoveredStateBuilder {
 
     last_committed_leader: Option<BlockReference>,
     committed_blocks: HashSet<BlockReference>,
+    last_committed_height: u64,
     committed_state: Option<Bytes>,
 }
 
@@ -62,6 +64,8 @@ impl RecoveredStateBuilder {
             self.last_committed_leader = Some(commit_data.leader);
             self.committed_blocks
                 .extend(commit_data.sub_dag.into_iter());
+            assert!(commit_data.height > self.last_committed_height);
+            self.last_committed_height = commit_data.height;
         }
         self.committed_state = Some(committed_state);
     }
@@ -81,6 +85,7 @@ impl RecoveredStateBuilder {
             last_committed_leader: self.last_committed_leader,
             committed_blocks: self.committed_blocks,
             committed_state: self.committed_state,
+            last_committed_height: self.last_committed_height,
         }
     }
 }


### PR DESCRIPTION
This PR introduces `CommitSubDag::height` which is a simple index of the sub dag in the commit sequence.

In addition, this PR adds few doc comments for commit related data structures and traits.

This PR also refactors recovery code by introducing `CommitObserverRecoveredState` structure, replacing a tuple of arguments passed to the commit observer - this is probably majority of code changes in this PR.