### PR TITLE
[refactor] Add BlockStore into CommitObserver and Linearizer

### DIFF
--- a/mysticeti-core/src/syncer.rs
+++ b/mysticeti-core/src/syncer.rs
@@ -91,9 +91,7 @@ impl<H: BlockHandler, S: SyncerSignals, C: CommitObserver> Syncer<H, S, C> {
                     .collect();
                 tracing::debug!("Committed {:?}", committed_refs);
             }
-            let committed_subdag = self
-                .commit_observer
-                .handle_commit(self.core.block_store(), newly_committed);
+            let committed_subdag = self.commit_observer.handle_commit(newly_committed);
             self.core.handle_committed_subdag(
                 committed_subdag,
                 &self.commit_observer.aggregator_state(),

--- a/mysticeti-core/src/test_util.rs
+++ b/mysticeti-core/src/test_util.rs
@@ -147,6 +147,7 @@ pub fn committee_and_syncers(
             .into_iter()
             .map(|core| {
                 let commit_handler = TestCommitObserver::new(
+                    core.block_store().clone(),
                     committee.clone(),
                     core.block_handler().transaction_time.clone(),
                     test_metrics(),
@@ -199,6 +200,7 @@ pub fn simulated_network_syncers_with_epoch_duration(
     let mut network_syncers = vec![];
     for (network, core) in networks.into_iter().zip(cores.into_iter()) {
         let commit_handler = TestCommitObserver::new(
+            core.block_store().clone(),
             committee.clone(),
             core.block_handler().transaction_time.clone(),
             core.metrics.clone(),
@@ -233,6 +235,7 @@ pub async fn network_syncers_with_epoch_duration(
     let mut network_syncers = vec![];
     for (network, core) in networks.into_iter().zip(cores.into_iter()) {
         let commit_handler = TestCommitObserver::new(
+            core.block_store().clone(),
             committee.clone(),
             core.block_handler().transaction_time.clone(),
             test_metrics(),

--- a/mysticeti-core/src/validator.rs
+++ b/mysticeti-core/src/validator.rs
@@ -129,6 +129,7 @@ impl Validator {
             TransactionLog::start(config.storage().committed_transactions_log())
                 .expect("Failed to open committed transaction log for write");
         let commit_handler = TestCommitObserver::new_with_handler(
+            recovered.block_store.clone(),
             committee.clone(),
             block_handler.transaction_time.clone(),
             metrics.clone(),


### PR DESCRIPTION
Right now we pass BlockStore as an argument every call to the `CommitObserver` and `Linearizer`. This was an artefact of very early days when BlockStore was not cloneable. Since it can be cloned now, it is more natural to just keep it in the CommitObserver and Linearizer instance instead of passing it throught the call chain.

It will also come useful later when we need to use BlockHandler during replay