### PR TITLE
Support proper committed state recovery and replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1738,7 @@ dependencies = [
  "gettid",
  "hex",
  "hyper",
+ "itertools 0.11.0",
  "libc",
  "memmap2",
  "minibytes",
@@ -2193,7 +2203,7 @@ version = "0.2.3"
 source = "git+https://github.com/asonnino/prometheus-parser.git?rev=75334db#75334dbe2d286edf6d4424abba92a74643333096"
 dependencies = [
  "chrono",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "regex",
 ]

--- a/mysticeti-core/Cargo.toml
+++ b/mysticeti-core/Cargo.toml
@@ -37,6 +37,7 @@ zeroize = "1.6.0"
 tabled = "0.12.2"
 gettid = "0.1.2"
 crc32fast = "1.3.2"
+itertools = "0.11.0"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/mysticeti-core/Cargo.toml
+++ b/mysticeti-core/Cargo.toml
@@ -37,9 +37,9 @@ zeroize = "1.6.0"
 tabled = "0.12.2"
 gettid = "0.1.2"
 crc32fast = "1.3.2"
-itertools = "0.11.0"
 
 [dev-dependencies]
+itertools = "0.11.0"
 reqwest = { workspace = true }
 tracing-test = "0.2.4"
 tempdir = "0.3.7"

--- a/mysticeti-core/src/block_store.rs
+++ b/mysticeti-core/src/block_store.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::commit_observer::CommitObserverRecoveredState;
 use crate::metrics::{Metrics, UtilizationTimerExt};
-use crate::state::{RecoveredState, RecoveredStateBuilder};
+use crate::state::{CoreRecoveredState, RecoveredStateBuilder};
 use crate::types::{AuthorityIndex, BlockDigest, BlockReference, RoundNumber, StatementBlock};
 use crate::wal::{Tag, WalPosition, WalReader, WalWriter};
 use crate::{committee::Committee, types::TransactionLocator};
@@ -52,7 +53,7 @@ impl BlockStore {
         wal_writer: &WalWriter,
         metrics: Arc<Metrics>,
         committee: &Committee,
-    ) -> RecoveredState {
+    ) -> (CoreRecoveredState, CommitObserverRecoveredState) {
         let last_seen_by_authority = committee.authorities().map(|_| 0).collect();
         let mut inner = BlockStoreInner {
             authority,

--- a/mysticeti-core/src/commit_observer.rs
+++ b/mysticeti-core/src/commit_observer.rs
@@ -235,6 +235,8 @@ impl SimpleCommitObserver {
         for commit_data in recovered_state.sub_dags {
             // Resend all the committed subdags to the consensus output channel for all the commits
             // above the last sent height.
+            // TODO: Since commit data is ordered by height, we can optimize this by first doing
+            // a binary search and skip all the commits below the last sent height.
             if commit_data.height > last_sent_height {
                 let committed_subdag =
                     CommittedSubDag::new_from_commit_data(commit_data, &self.block_store);

--- a/mysticeti-core/src/commit_observer.rs
+++ b/mysticeti-core/src/commit_observer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block_store::BlockStore;
+use crate::block_store::{BlockStore, CommitData};
 use crate::committee::{
     Committee, ProcessedTransactionHandler, QuorumThreshold, TransactionAggregator,
 };
@@ -29,18 +29,12 @@ pub trait CommitObserver: Send + Sync {
 
     /// If CommitObserver has an aggregator (such as TransactionAggregator for fast path), this method return serialized state of such aggregator to be persisted in wal.
     fn aggregator_state(&self) -> Bytes;
-
-    /// When core is restored from wal, it calls CommitObserver::recover_committed and passes the relevant information recovered from wal(see CommitObserverRecoveredState).
-    /// recover_committed is guaranteed to be called on CommitObserver before any other call(e.g. handle_commit or aggregator_state).
-    /// recover_committed is only called if core is recovered from wal, for newly created instance of the protocol recover_committed won't be called.
-    fn recover_committed(&mut self, state: CommitObserverRecoveredState);
 }
 
+#[derive(Default)]
 pub struct CommitObserverRecoveredState {
-    /// set of references of all previously committed blocks
-    pub committed: HashSet<BlockReference>,
-    /// height of the last committed sub dag. This is 0 if no subdags were committed
-    pub last_committed_height: u64,
+    /// All previously committed subdags.
+    pub sub_dags: Vec<CommitData>,
     /// Last observed state of the commit observer returned by CommitObserver::aggregator_state
     pub state: Option<Bytes>,
 }
@@ -59,32 +53,34 @@ pub struct TestCommitObserver<H = HashSet<TransactionLocator>> {
 }
 
 impl<H: ProcessedTransactionHandler<TransactionLocator> + Default> TestCommitObserver<H> {
-    pub fn new(
+    pub fn new_for_testing(
         block_store: BlockStore,
         committee: Arc<Committee>,
         transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
         metrics: Arc<Metrics>,
     ) -> Self {
-        Self::new_with_handler(
+        Self::new(
             block_store,
             committee,
             transaction_time,
             metrics,
+            Default::default(),
             Default::default(),
         )
     }
 }
 
 impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitObserver<H> {
-    pub fn new_with_handler(
+    pub fn new(
         block_store: BlockStore,
         committee: Arc<Committee>,
         transaction_time: Arc<Mutex<HashMap<TransactionLocator, TimeInstant>>>,
         metrics: Arc<Metrics>,
         handler: H,
+        recovered_state: CommitObserverRecoveredState,
     ) -> Self {
         let consensus_only = env::var("CONSENSUS_ONLY").is_ok();
-        Self {
+        let mut observer = Self {
             commit_interpreter: Linearizer::new(block_store),
             transaction_votes: TransactionAggregator::with_handler(handler),
             committee,
@@ -95,7 +91,9 @@ impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitObserver<H> {
 
             metrics,
             consensus_only,
-        }
+        };
+        observer.recover_committed(recovered_state);
+        observer
     }
 
     pub fn committed_leaders(&self) -> &Vec<BlockReference> {
@@ -139,6 +137,15 @@ impl<H: ProcessedTransactionHandler<TransactionLocator>> TestCommitObserver<H> {
             .latency_squared_s
             .with_label_values(&["shared"])
             .inc_by(square_latency);
+    }
+
+    fn recover_committed(&mut self, recovered_state: CommitObserverRecoveredState) {
+        if let Some(state) = &recovered_state.state {
+            self.transaction_votes.with_state(state);
+        } else {
+            assert!(recovered_state.sub_dags.is_empty());
+        }
+        self.commit_interpreter.recover_state(&recovered_state);
     }
 }
 
@@ -188,18 +195,6 @@ impl<H: ProcessedTransactionHandler<TransactionLocator> + Send + Sync> CommitObs
     fn aggregator_state(&self) -> Bytes {
         self.transaction_votes.state()
     }
-
-    fn recover_committed(&mut self, recovered_state: CommitObserverRecoveredState) {
-        if let Some(state) = recovered_state.state {
-            self.transaction_votes.with_state(&state);
-        } else {
-            assert!(recovered_state.committed.is_empty());
-        }
-        self.commit_interpreter.recover_state(
-            recovered_state.committed,
-            recovered_state.last_committed_height,
-        );
-    }
 }
 
 pub struct SimpleCommitObserver {
@@ -216,15 +211,37 @@ impl SimpleCommitObserver {
         block_store: BlockStore,
         // Channel where core will send commits, application can read commits form the other end
         sender: tokio::sync::mpsc::UnboundedSender<CommittedSubDag>,
-        // Last CommittedSubDag::height(excluded) that we need to replay commits from.
-        // First commit in the replayed sequence will have height replay_from_height+1.
-        // Set to 0 to replay from the start.
-        _replay_from_height: u64,
+        // Last CommittedSubDag::height that has been successfully sent to the output channel.
+        // First commit in the replayed sequence will have height last_sent_height + 1.
+        // Set to 0 to replay from the start (as normal sequence starts at height = 1).
+        last_sent_height: u64,
+        recover_state: CommitObserverRecoveredState,
     ) -> Self {
-        Self {
+        let mut observer = Self {
             block_store: block_store.clone(),
             commit_interpreter: Linearizer::new(block_store),
             sender,
+        };
+        observer.recover_committed(last_sent_height, recover_state);
+        observer
+    }
+
+    fn recover_committed(
+        &mut self,
+        last_sent_height: u64,
+        recovered_state: CommitObserverRecoveredState,
+    ) {
+        self.commit_interpreter.recover_state(&recovered_state);
+        for commit_data in recovered_state.sub_dags {
+            // Resend all the committed subdags to the consensus output channel for all the commits
+            // above the last sent height.
+            if commit_data.height > last_sent_height {
+                let committed_subdag =
+                    CommittedSubDag::new_from_commit_data(commit_data, &self.block_store);
+                if let Err(err) = self.sender.send(committed_subdag) {
+                    tracing::error!("Failed to send committed sub-dag: {:?}", err);
+                }
+            }
         }
     }
 }
@@ -246,15 +263,5 @@ impl CommitObserver for SimpleCommitObserver {
 
     fn aggregator_state(&self) -> Bytes {
         Bytes::new()
-    }
-
-    fn recover_committed(&mut self, recovered_state: CommitObserverRecoveredState) {
-        // The committed state is set only when we care about fast path aggregation. It must be
-        // empty for the simple observer right now.
-        assert!(recovered_state.state.map(|s| s.is_empty()).unwrap_or(true));
-        self.commit_interpreter.recover_state(
-            recovered_state.committed,
-            recovered_state.last_committed_height,
-        );
     }
 }

--- a/mysticeti-core/src/consensus/linearizer.rs
+++ b/mysticeti-core/src/consensus/linearizer.rs
@@ -60,7 +60,7 @@ impl CommittedSubDag {
             .collect::<Vec<_>>();
         let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
         let leader_block_ref = blocks[leader_block_idx].reference();
-        let timestamp_ms = (blocks[leader_block_idx].meta_creation_time_ns() / 1000) as u64;
+        let timestamp_ms = blocks[leader_block_idx].meta_creation_time_ms();
         CommittedSubDag::new(*leader_block_ref, blocks, timestamp_ms, commit_data.height)
     }
 
@@ -125,8 +125,7 @@ impl Linearizer {
     fn collect_sub_dag(&mut self, leader_block: Data<StatementBlock>) -> CommittedSubDag {
         let mut to_commit = Vec::new();
 
-        // TODO: Verify that this can never overflow.
-        let timestamp_ms = (leader_block.meta_creation_time_ns() / 1000) as u64;
+        let timestamp_ms = leader_block.meta_creation_time_ms();
         let leader_block_ref = *leader_block.reference();
         let mut buffer = vec![leader_block];
         assert!(self.committed.insert(leader_block_ref));

--- a/mysticeti-core/src/net_sync.rs
+++ b/mysticeti-core/src/net_sync.rs
@@ -45,9 +45,9 @@ pub struct NetworkSyncerInner<H: BlockHandler, C: CommitObserver> {
 impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C> {
     pub fn start(
         network: Network,
-        mut core: Core<H>,
+        core: Core<H>,
         commit_period: u64,
-        mut commit_observer: C,
+        commit_observer: C,
         shutdown_grace_period: Duration,
         validator: impl BlockValidator,
         metrics: Arc<Metrics>,
@@ -55,9 +55,6 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
         let authority_index = core.authority();
         let handle = Handle::current();
         let notify = Arc::new(Notify::new());
-        // todo - ugly, probably need to merge syncer and core
-        let commit_observer_state = core.take_recovered_committed_blocks();
-        commit_observer.recover_committed(commit_observer_state);
         let committee = core.committee().clone();
         let wal_syncer = core.wal_syncer();
         let block_store = core.block_store().clone();

--- a/mysticeti-core/src/types.rs
+++ b/mysticeti-core/src/types.rs
@@ -261,6 +261,11 @@ impl StatementBlock {
         self.meta_creation_time_ns
     }
 
+    pub fn meta_creation_time_ms(&self) -> u64 {
+        // TODO: Verify that this will never overflow.
+        (self.meta_creation_time_ns / 1000) as u64
+    }
+
     pub fn epoch_changed(&self) -> EpochStatus {
         self.epoch_marker
     }


### PR DESCRIPTION
This PR adds support to the SimpleCommitObserver to be able to resend committed subdags to consensus output channel, for anything that hasn't been sent yet during recovery.
It also cleans up the recovery state by splitting it into two states, initialized when opening the block store.
