### PR TITLE
[performance improvement] cache votes and link to block

### DIFF
--- a/mysticeti-core/src/block_store.rs
+++ b/mysticeti-core/src/block_store.rs
@@ -319,6 +319,9 @@ impl BlockStore {
                         .any(|x| x.includes().contains(block.reference()))
                 })
                 .collect();
+            if parents.is_empty() {
+                break;
+            }
         }
         parents
     }
@@ -572,11 +575,74 @@ impl From<&CommittedSubDag> for CommitData {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::crypto::SignatureBytes;
+    use crate::test_util::{committee, TestBlockWriter};
+    use crate::types::EpochStatus;
 
     #[test]
     fn own_block_serialization_test() {
         let next_entry = WalPosition::default();
         let serialized = bincode::serialize(&next_entry).unwrap();
         assert_eq!(serialized.len(), OWN_BLOCK_HEADER_SIZE);
+    }
+
+    #[test]
+    fn linked_to_round_test() {
+        // GIVEN
+        let committee = committee(4);
+        let mut block_writer = TestBlockWriter::new(&committee);
+
+        let mut references = Vec::new();
+        for round in 1..=4 {
+            let block = Data::new(StatementBlock::new(
+                0,
+                round,
+                references.clone(),
+                vec![],
+                0,
+                EpochStatus::default(),
+                0,
+                SignatureBytes::default(),
+            ));
+            references = vec![*block.reference()];
+            block_writer.add_block(block.clone());
+        }
+
+        let binding = block_writer.block_store().get_blocks_by_round(4);
+        let last_block = binding.first().unwrap();
+
+        // WHEN
+        let blocks_round_1 = block_writer.block_store().linked_to_round(last_block, 1);
+
+        // THEN
+        assert_eq!(blocks_round_1.len(), 1);
+        assert_eq!(blocks_round_1.first().unwrap().author(), 0);
+
+        // AND create now a new chain of blocks, independent, for another authority
+        let mut references = Vec::new();
+        for round in 1..=4 {
+            let block = Data::new(StatementBlock::new(
+                1,
+                round,
+                references.clone(),
+                vec![],
+                0,
+                EpochStatus::default(),
+                0,
+                SignatureBytes::default(),
+            ));
+            references = vec![*block.reference()];
+            block_writer.add_block(block.clone());
+        }
+
+        // WHEN
+        let binding = block_writer.block_store().get_blocks_by_round(4);
+        let last_block = binding.iter().filter(|b| b.author() == 1).next().unwrap();
+
+        let blocks_round_1 = block_writer.block_store().linked_to_round(last_block, 1);
+
+        // THEN it should give us only the block of authority 1
+        assert_eq!(blocks_round_1.len(), 1);
+        assert_eq!(blocks_round_1.first().unwrap().author(), 1);
     }
 }

--- a/mysticeti-core/src/consensus/base_committer.rs
+++ b/mysticeti-core/src/consensus/base_committer.rs
@@ -142,7 +142,10 @@ impl BaseCommitter {
     }
 
     /// Check whether the specified block (`potential_certificate`) is a certificate for
-    /// the specified leader (`leader_block`).
+    /// the specified leader (`leader_block`). An `all_votes` map can be provided as a cache to quickly
+    /// skip checking against the block store on whether a reference is a vote. This is done for efficiency.
+    /// Bear in mind that the `all_votes` should refer to votes considered to the same `leader_block` and it can't
+    /// be reused for different leaders.
     fn is_certificate(
         &self,
         potential_certificate: &Data<StatementBlock>,


### PR DESCRIPTION
Under circumstances the commit rule on a 150 validator network could take 10s of miliseconds per commit to execute. That could be proven particularly slow especially when experiencing some asynchrony. Also a slow commit rule wouldn't allow us to execute it more frequently as well given that is part of the block processing path.

This PR is:
* caching the votes when trying to figure out whether a block is a certificate. That would make all the other checks of the quorum much faster as it would reduce the iterations hopefully from an NxNxM to NxN
*  replace the `linked` method with a `linked_to_round` to avoid iterating and checking the link path for every single certificate
* quickly return from `enough_leader_support` when there isn't enough stake

the above with some additional improvements which will be added on a follow up PR manage to reduce the commit latency to `~3.7ms` per try_commit run.