### PR TITLE
[refactor] avoid re-processing unnecessary rounds & metrics improvements

### DIFF
--- a/mysticeti-core/src/config.rs
+++ b/mysticeti-core/src/config.rs
@@ -44,6 +44,9 @@ pub struct Parameters {
     pub shutdown_grace_period: Duration,
     pub number_of_leaders: usize,
     pub enable_pipelining: bool,
+    // The number of rounds to be retained when periodically cleaning up the store from in memory
+    // block data and keeping only the indexes.
+    pub store_retain_rounds: u64,
 }
 
 impl Default for Parameters {
@@ -55,6 +58,7 @@ impl Default for Parameters {
             rounds_in_epoch: Self::DEFAULT_ROUNDS_IN_EPOCH,
             shutdown_grace_period: Self::DEFAULT_SHUTDOWN_GRACE_PERIOD,
             number_of_leaders: Self::DEFAULT_NUMBER_OF_LEADERS,
+            store_retain_rounds: Self::DEFAULT_STORE_RETAIN_ROUNDS,
             enable_pipelining: true,
         }
     }
@@ -73,6 +77,8 @@ impl Parameters {
     pub const DEFAULT_SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(2);
 
     pub const DEFAULT_NUMBER_OF_LEADERS: usize = 1;
+
+    pub const DEFAULT_STORE_RETAIN_ROUNDS: u64 = 500;
 
     pub fn new_for_benchmarks(ips: Vec<IpAddr>) -> Self {
         let benchmark_port_offset = ips.len() as u16;

--- a/mysticeti-core/src/consensus/mod.rs
+++ b/mysticeti-core/src/consensus/mod.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Display;
 
+use crate::types::AuthorityRound;
 use crate::{
     data::Data,
     types::{format_authority_round, AuthorityIndex, RoundNumber, StatementBlock},
@@ -57,7 +58,15 @@ impl LeaderStatus {
         }
     }
 
-    pub fn into_decided_block(self) -> Option<Data<StatementBlock>> {
+    pub fn into_decided_author_round(self) -> AuthorityRound {
+        match self {
+            Self::Commit(block) => AuthorityRound::new(block.author(), block.round()),
+            Self::Skip(authority, round) => AuthorityRound::new(authority, round),
+            Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
+        }
+    }
+
+    pub fn into_committed_block(self) -> Option<Data<StatementBlock>> {
         match self {
             Self::Commit(block) => Some(block),
             Self::Skip(..) => None,

--- a/mysticeti-core/src/consensus/mod.rs
+++ b/mysticeti-core/src/consensus/mod.rs
@@ -29,39 +29,45 @@ pub const MINIMUM_WAVE_LENGTH: RoundNumber = 3;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum LeaderStatus {
     Commit(Data<StatementBlock>),
-    Skip(AuthorityIndex, RoundNumber),
-    Undecided(AuthorityIndex, RoundNumber),
+    Skip(AuthorityRound),
+    Undecided(AuthorityRound),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Decision {
+    Direct,
+    Indirect,
 }
 
 impl LeaderStatus {
     pub fn round(&self) -> RoundNumber {
         match self {
             Self::Commit(block) => block.round(),
-            Self::Skip(_, round) => *round,
-            Self::Undecided(_, round) => *round,
+            Self::Skip(leader) => leader.round,
+            Self::Undecided(leader) => leader.round,
         }
     }
 
     pub fn authority(&self) -> AuthorityIndex {
         match self {
             Self::Commit(block) => block.author(),
-            Self::Skip(authority, _) => *authority,
-            Self::Undecided(authority, _) => *authority,
+            Self::Skip(leader) => leader.authority,
+            Self::Undecided(leader) => leader.authority,
         }
     }
 
     pub fn is_decided(&self) -> bool {
         match self {
             Self::Commit(_) => true,
-            Self::Skip(_, _) => true,
-            Self::Undecided(_, _) => false,
+            Self::Skip(_) => true,
+            Self::Undecided(_) => false,
         }
     }
 
     pub fn into_decided_author_round(self) -> AuthorityRound {
         match self {
             Self::Commit(block) => AuthorityRound::new(block.author(), block.round()),
-            Self::Skip(authority, round) => AuthorityRound::new(authority, round),
+            Self::Skip(leader) => leader,
             Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
         }
     }
@@ -91,8 +97,16 @@ impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Commit(block) => write!(f, "Commit({})", block.reference()),
-            Self::Skip(a, r) => write!(f, "Skip({})", format_authority_round(*a, *r)),
-            Self::Undecided(a, r) => write!(f, "Undecided({})", format_authority_round(*a, *r)),
+            Self::Skip(leader) => write!(
+                f,
+                "Skip({})",
+                format_authority_round(leader.authority, leader.round)
+            ),
+            Self::Undecided(leader) => write!(
+                f,
+                "Undecided({})",
+                format_authority_round(leader.authority, leader.round)
+            ),
         }
     }
 }

--- a/mysticeti-core/src/consensus/tests/base_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/base_committer_tests.rs
@@ -212,9 +212,9 @@ fn no_leader() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
-        assert_eq!(leader, leader_1);
-        assert_eq!(round, leader_round_1);
+    if let LeaderStatus::Skip(leader) = sequence[0] {
+        assert_eq!(leader.authority, leader_1);
+        assert_eq!(leader.round, leader_round_1);
     } else {
         panic!("Expected to directly skip the leader");
     }
@@ -262,9 +262,9 @@ fn direct_skip() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
-        assert_eq!(leader, committee.elect_leader(leader_round_1, 0));
-        assert_eq!(round, leader_round_1);
+    if let LeaderStatus::Skip(leader) = sequence[0] {
+        assert_eq!(leader.authority, committee.elect_leader(leader_round_1, 0));
+        assert_eq!(leader.round, leader_round_1);
     } else {
         panic!("Expected to directly skip the leader");
     }
@@ -445,9 +445,9 @@ fn indirect_skip() {
 
     // Ensure we skip the 2nd leader.
     let leader_round_2 = 2 * wave_length;
-    if let LeaderStatus::Skip(leader, round) = sequence[1] {
-        assert_eq!(leader, leader_2);
-        assert_eq!(round, leader_round_2);
+    if let LeaderStatus::Skip(leader) = sequence[1] {
+        assert_eq!(leader.authority, leader_2);
+        assert_eq!(leader.round, leader_round_2);
     } else {
         panic!("Expected a skipped leader")
     }

--- a/mysticeti-core/src/consensus/tests/base_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/base_committer_tests.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::AuthorityRound;
 use crate::{
     consensus::{
         universal_committer::UniversalCommitterBuilder, LeaderStatus, DEFAULT_WAVE_LENGTH,
     },
     test_util::{build_dag, build_dag_layer, committee, test_metrics, TestBlockWriter},
-    types::BlockReference,
 };
 
 /// Commit one leader.
@@ -25,7 +25,7 @@ fn direct_commit() {
     )
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -57,12 +57,12 @@ fn idempotence() {
     .build();
 
     // Commit one block.
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let committed = committer.try_commit(last_committed);
 
     // Ensure we don't commit it again.
     let max = committed.into_iter().max().unwrap();
-    let last_committed = BlockReference::new_test(max.authority(), max.round());
+    let last_committed = AuthorityRound::new(max.authority(), max.round());
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());
@@ -75,7 +75,7 @@ fn multiple_direct_commit() {
     let committee = committee(4);
     let wave_length = DEFAULT_WAVE_LENGTH;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed = AuthorityRound::new(0, 0);
     for n in 1..=10 {
         let enough_blocks = wave_length * (n + 1) - 1;
         let mut block_writer = TestBlockWriter::new(&committee);
@@ -101,7 +101,7 @@ fn multiple_direct_commit() {
         }
 
         let max = sequence.iter().max().unwrap();
-        last_committed = BlockReference::new_test(max.authority(), max.round());
+        last_committed = AuthorityRound::new(max.authority(), max.round());
     }
 }
 
@@ -125,7 +125,7 @@ fn direct_commit_late_call() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -160,7 +160,7 @@ fn no_genesis_commit() {
         .with_wave_length(wave_length)
         .build();
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed = AuthorityRound::new(0, 0);
         let sequence = committer.try_commit(last_committed);
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -207,7 +207,7 @@ fn no_leader() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -257,7 +257,7 @@ fn direct_skip() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -353,7 +353,7 @@ fn indirect_commit() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 2);
@@ -429,7 +429,7 @@ fn indirect_skip() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 3);
@@ -511,7 +511,7 @@ fn undecided() {
     .with_wave_length(wave_length)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());

--- a/mysticeti-core/src/consensus/tests/multi_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/multi_committer_tests.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::AuthorityRound;
 use crate::{
     consensus::{
         universal_committer::UniversalCommitterBuilder, LeaderStatus, DEFAULT_WAVE_LENGTH,
     },
     test_util::{build_dag, build_dag_layer, committee, test_metrics, TestBlockWriter},
-    types::BlockReference,
 };
 
 /// Commit the leaders of the first wave.
@@ -28,7 +28,7 @@ fn direct_commit() {
         .with_number_of_leaders(number_of_leaders)
         .build();
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed = AuthorityRound::new(0, 0);
         let sequence = committer.try_commit(last_committed);
         tracing::info!("Commit sequence: {sequence:?}");
 
@@ -66,12 +66,12 @@ fn idempotence() {
         .build();
 
         // Commit one block.
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed = AuthorityRound::new(0, 0);
         let committed = committer.try_commit(last_committed);
 
         // Ensure we don't commit it again.
         let last = committed.into_iter().last().unwrap();
-        let last_committed = BlockReference::new_test(last.authority(), last.round());
+        let last_committed = AuthorityRound::new(last.authority(), last.round());
         let sequence = committer.try_commit(last_committed);
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -86,7 +86,7 @@ fn multiple_direct_commit() {
     let wave_length = DEFAULT_WAVE_LENGTH;
     let number_of_leaders = committee.quorum_threshold() as usize;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed = AuthorityRound::new(0, 0);
     for n in 1..=10 {
         let enough_blocks = wave_length * (n + 1) - 1;
         let mut block_writer = TestBlockWriter::new(&committee);
@@ -117,7 +117,7 @@ fn multiple_direct_commit() {
         }
 
         let last = sequence.iter().last().unwrap();
-        last_committed = BlockReference::new_test(last.authority(), last.round());
+        last_committed = AuthorityRound::new(last.authority(), last.round());
     }
 }
 
@@ -131,7 +131,7 @@ fn direct_commit_partial_round() {
 
     let first_leader_round = wave_length;
     let first_leader = committee.elect_leader(first_leader_round, 0);
-    let last_committed = BlockReference::new_test(first_leader, first_leader_round);
+    let last_committed = AuthorityRound::new(first_leader, first_leader_round);
 
     let enough_blocks = 2 * wave_length - 1;
     let mut block_writer = TestBlockWriter::new(&committee);
@@ -183,7 +183,7 @@ fn direct_commit_late_call() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -224,7 +224,7 @@ fn no_genesis_commit() {
         .with_number_of_leaders(number_of_leaders)
         .build();
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed = AuthorityRound::new(0, 0);
         let sequence = committer.try_commit(last_committed);
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -273,7 +273,7 @@ fn no_leader() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -338,7 +338,7 @@ fn direct_skip() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -449,7 +449,7 @@ fn indirect_commit() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 2 * number_of_leaders);
@@ -527,7 +527,7 @@ fn indirect_skip() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 3 * number_of_leaders);
@@ -637,7 +637,7 @@ fn undecided() {
     .with_number_of_leaders(number_of_leaders)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());

--- a/mysticeti-core/src/consensus/tests/multi_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/multi_committer_tests.rs
@@ -283,9 +283,9 @@ fn no_leader() {
         let leader_offset = i as u64;
         let expected_leader = committee.elect_leader(leader_round, leader_offset);
         if i == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[i] {
-                assert_eq!(leader, expected_leader);
-                assert_eq!(round, leader_round_1);
+            if let LeaderStatus::Skip(leader) = sequence[i] {
+                assert_eq!(leader.authority, expected_leader);
+                assert_eq!(leader.round, leader_round_1);
             } else {
                 panic!("Expected to directly skip the leader");
             }
@@ -348,9 +348,9 @@ fn direct_skip() {
         let leader_offset = i as u64;
         let expected_leader = committee.elect_leader(leader_round, leader_offset);
         if i == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[i] {
-                assert_eq!(leader, expected_leader);
-                assert_eq!(round, leader_round_1);
+            if let LeaderStatus::Skip(leader) = sequence[i] {
+                assert_eq!(leader.authority, expected_leader);
+                assert_eq!(leader.round, leader_round_1);
             } else {
                 panic!("Expected to directly skip the leader");
             }
@@ -546,9 +546,9 @@ fn indirect_skip() {
 
     // Ensure we skip the first leader of wave 2 but commit the other leaders of wave 2.
     let leader_round_2 = 2 * wave_length;
-    if let LeaderStatus::Skip(leader, round) = sequence[number_of_leaders] {
-        assert_eq!(leader, leader_2);
-        assert_eq!(round, leader_round_2);
+    if let LeaderStatus::Skip(leader) = sequence[number_of_leaders] {
+        assert_eq!(leader.authority, leader_2);
+        assert_eq!(leader.round, leader_round_2);
     } else {
         panic!("Expected a skipped leader")
     }
@@ -557,9 +557,9 @@ fn indirect_skip() {
         let leader_round_2 = 2 * wave_length;
         let leader_offset = n as u64;
         if n == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[number_of_leaders + n] {
-                assert_eq!(leader, leader_2);
-                assert_eq!(round, leader_round_2);
+            if let LeaderStatus::Skip(leader) = sequence[number_of_leaders + n] {
+                assert_eq!(leader.authority, leader_2);
+                assert_eq!(leader.round, leader_round_2);
             } else {
                 panic!("Expected a skipped leader")
             }

--- a/mysticeti-core/src/consensus/tests/pipelined_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/pipelined_committer_tests.rs
@@ -220,9 +220,9 @@ fn no_leader() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
-        assert_eq!(leader, leader_1);
-        assert_eq!(round, leader_round_1);
+    if let LeaderStatus::Skip(leader) = sequence[0] {
+        assert_eq!(leader.authority, leader_1);
+        assert_eq!(leader.round, leader_round_1);
     } else {
         panic!("Expected to directly skip the leader");
     }
@@ -271,9 +271,9 @@ fn direct_skip() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
-        assert_eq!(leader, committee.elect_leader(leader_round_1, 0));
-        assert_eq!(round, leader_round_1);
+    if let LeaderStatus::Skip(leader) = sequence[0] {
+        assert_eq!(leader.authority, committee.elect_leader(leader_round_1, 0));
+        assert_eq!(leader.round, leader_round_1);
     } else {
         panic!("Expected to directly skip the leader");
     }
@@ -458,9 +458,9 @@ fn indirect_skip() {
     }
 
     // Ensure we skip the leader of wave 1 (first pipeline) but commit the others.
-    if let LeaderStatus::Skip(leader, round) = sequence[3] {
-        assert_eq!(leader, committee.elect_leader(leader_round_4, 0));
-        assert_eq!(round, leader_round_4);
+    if let LeaderStatus::Skip(leader) = sequence[3] {
+        assert_eq!(leader.authority, committee.elect_leader(leader_round_4, 0));
+        assert_eq!(leader.round, leader_round_4);
     } else {
         panic!("Expected a skipped leader")
     }

--- a/mysticeti-core/src/consensus/tests/pipelined_committer_tests.rs
+++ b/mysticeti-core/src/consensus/tests/pipelined_committer_tests.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::AuthorityRound;
 use crate::{
     consensus::{
         universal_committer::UniversalCommitterBuilder, LeaderStatus, DEFAULT_WAVE_LENGTH,
     },
     test_util::{build_dag, build_dag_layer, committee, test_metrics, TestBlockWriter},
-    types::{BlockReference, StatementBlock},
+    types::StatementBlock,
 };
 
 /// Commit one leader.
@@ -28,7 +29,7 @@ fn direct_commit() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -60,12 +61,12 @@ fn idempotence() {
     .build();
 
     // Commit one block.
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let committed = committer.try_commit(last_committed);
 
     // Ensure we don't commit it again.
     let last = committed.into_iter().last().unwrap();
-    let last_committed = BlockReference::new_test(last.authority(), last.round());
+    let last_committed = AuthorityRound::new(last.authority(), last.round());
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());
@@ -78,7 +79,7 @@ fn multiple_direct_commit() {
     let committee = committee(4);
     let wave_length = DEFAULT_WAVE_LENGTH;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed = AuthorityRound::new(0, 0);
     for n in 1..=10 {
         let enough_blocks = n + (wave_length - 1);
         let mut block_writer = TestBlockWriter::new(&committee);
@@ -105,7 +106,7 @@ fn multiple_direct_commit() {
         }
 
         let last = sequence.into_iter().last().unwrap();
-        last_committed = BlockReference::new_test(last.authority(), last.round());
+        last_committed = AuthorityRound::new(last.authority(), last.round());
     }
 }
 
@@ -130,7 +131,7 @@ fn direct_commit_late_call() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -166,7 +167,7 @@ fn no_genesis_commit() {
         .with_pipeline(true)
         .build();
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed = AuthorityRound::new(0, 0);
         let sequence = committer.try_commit(last_committed);
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -214,7 +215,7 @@ fn no_leader() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -265,7 +266,7 @@ fn direct_skip() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -364,7 +365,7 @@ fn indirect_commit() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 5);
@@ -440,7 +441,7 @@ fn indirect_skip() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 7);
@@ -525,7 +526,7 @@ fn undecided() {
     .with_pipeline(true)
     .build();
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed = AuthorityRound::new(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());

--- a/mysticeti-core/src/consensus/universal_committer.rs
+++ b/mysticeti-core/src/consensus/universal_committer.rs
@@ -12,7 +12,7 @@ use crate::{
     types::{format_authority_round, AuthorityIndex, RoundNumber},
 };
 
-use super::{base_committer::BaseCommitter, LeaderStatus, DEFAULT_WAVE_LENGTH};
+use super::{base_committer::BaseCommitter, Decision, LeaderStatus, DEFAULT_WAVE_LENGTH};
 
 /// A universal committer uses a collection of committers to commit a sequence of leaders.
 /// It can be configured to use a combination of different commit strategies, including
@@ -29,13 +29,13 @@ impl UniversalCommitter {
     #[tracing::instrument(skip_all, fields(last_decided = %last_decided))]
     pub fn try_commit(&self, last_decided: AuthorityRound) -> Vec<LeaderStatus> {
         let highest_known_round = self.block_store.highest_round();
-        // let last_decided_round = max(last_decided.round(), 1); // Skip genesis.
-        let last_decided_round = last_decided.round();
-        let last_decided_round_authority = (last_decided.round(), last_decided.authority);
 
         // Try to decide as many leaders as possible, starting with the highest round.
         let mut leaders = VecDeque::new();
-        'outer: for round in (last_decided_round..=highest_known_round.saturating_sub(2)).rev() {
+        // try to commit a leader up to the highest_known_round - 2. There is no reason to try and
+        // iterate on higher rounds as in order to make a direct decision for a leader at round R we
+        // need blocks from round R+2 to figure out that enough certificates and support exist to commit a leader.
+        'outer: for round in (last_decided.round()..=highest_known_round.saturating_sub(2)).rev() {
             for committer in self.committers.iter().rev() {
                 // Skip committers that don't have a leader for this round.
                 let Some(leader) = committer.elect_leader(round) else {
@@ -43,33 +43,31 @@ impl UniversalCommitter {
                 };
 
                 // now that we reached the last committed leader we can stop the commit rule
-                if (round, leader) == last_decided_round_authority {
+                if leader == last_decided {
                     tracing::debug!(
-                        "Leader of round {round} -> {leader} - reached last committed, now exit"
+                        "Leader of round {} -> {} - reached last committed, now exit",
+                        leader.round,
+                        leader.authority
                     );
                     break 'outer;
                 }
 
                 tracing::debug!(
                     "Trying to decide {} with {committer}",
-                    format_authority_round(leader, round)
+                    format_authority_round(leader.authority, leader.round)
                 );
 
                 // Try to directly decide the leader.
-                let mut status = committer.try_direct_decide(leader, round);
-                self.update_metrics(&status, true);
+                let mut status = committer.try_direct_decide(leader);
+                self.update_metrics(&status, Decision::Direct);
                 tracing::debug!("Outcome of direct rule: {status}");
 
                 // If we can't directly decide the leader, try to indirectly decide it.
                 if status.is_decided() {
-                    leaders.push_front((status.clone(), true));
+                    leaders.push_front((status.clone(), Decision::Direct));
                 } else {
-                    status = committer.try_indirect_decide(
-                        leader,
-                        round,
-                        leaders.iter().map(|(x, _)| x),
-                    );
-                    leaders.push_front((status.clone(), false));
+                    status = committer.try_indirect_decide(leader, leaders.iter().map(|(x, _)| x));
+                    leaders.push_front((status.clone(), Decision::Indirect));
                     tracing::debug!("Outcome of indirect rule: {status}");
                 }
             }
@@ -99,13 +97,18 @@ impl UniversalCommitter {
         self.committers
             .iter()
             .filter_map(|committer| committer.elect_leader(round))
+            .map(|l| l.authority)
             .collect()
     }
 
     /// Update metrics.
-    fn update_metrics(&self, leader: &LeaderStatus, direct_decide: bool) {
+    fn update_metrics(&self, leader: &LeaderStatus, decision: Decision) {
         let authority = leader.authority().to_string();
-        let direct_or_indirect = if direct_decide { "direct" } else { "indirect" };
+        let direct_or_indirect = if decision == Decision::Direct {
+            "direct"
+        } else {
+            "indirect"
+        };
         let status = match leader {
             LeaderStatus::Commit(..) => format!("{direct_or_indirect}-commit"),
             LeaderStatus::Skip(..) => format!("{direct_or_indirect}-skip"),

--- a/mysticeti-core/src/core.rs
+++ b/mysticeti-core/src/core.rs
@@ -49,6 +49,7 @@ pub struct Core<H: BlockHandler> {
     epoch_manager: EpochManager,
     rounds_in_epoch: RoundNumber,
     committer: UniversalCommitter,
+    store_retain_rounds: u64,
 }
 
 pub struct CoreOptions {
@@ -142,6 +143,7 @@ impl<H: BlockHandler> Core<H> {
             signer,
             epoch_manager,
             rounds_in_epoch: parameters.rounds_in_epoch(),
+            store_retain_rounds: parameters.store_retain_rounds,
             committer,
         };
 
@@ -352,12 +354,10 @@ impl<H: BlockHandler> Core<H> {
     }
 
     pub fn cleanup(&self) {
-        const RETAIN_BELOW_COMMIT_ROUNDS: RoundNumber = 500;
-
         self.block_store.cleanup(
             self.last_decided_leader
                 .round()
-                .saturating_sub(RETAIN_BELOW_COMMIT_ROUNDS),
+                .saturating_sub(self.store_retain_rounds),
         );
 
         self.block_handler.cleanup();

--- a/mysticeti-core/src/types.rs
+++ b/mysticeti-core/src/types.rs
@@ -69,6 +69,25 @@ impl Hash for BlockReference {
     }
 }
 
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct AuthorityRound {
+    pub authority: AuthorityIndex,
+    pub round: RoundNumber,
+}
+
+impl AuthorityRound {
+    pub fn new(authority: AuthorityIndex, round: RoundNumber) -> Self {
+        Self { authority, round }
+    }
+    pub fn round(&self) -> RoundNumber {
+        self.round
+    }
+
+    pub fn authority(&self) -> AuthorityIndex {
+        self.authority
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 // Important. Adding fields here requires updating BlockDigest::new, and StatementBlock::verify
 pub struct StatementBlock {
@@ -682,6 +701,33 @@ impl fmt::Display for BaseStatement {
                 "+{}:{}:{}",
                 range.block, range.offset_start_inclusive, range.offset_end_exclusive
             ),
+        }
+    }
+}
+
+impl From<BlockReference> for AuthorityRound {
+    fn from(value: BlockReference) -> Self {
+        AuthorityRound::new(value.authority, value.round)
+    }
+}
+
+impl fmt::Debug for AuthorityRound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for AuthorityRound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.authority < 26 {
+            write!(
+                f,
+                "{}{}",
+                format_authority_index(self.authority),
+                self.round
+            )
+        } else {
+            write!(f, "[{:02}]{}", self.authority, self.round)
         }
     }
 }

--- a/mysticeti-core/src/types.rs
+++ b/mysticeti-core/src/types.rs
@@ -69,7 +69,7 @@ impl Hash for BlockReference {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default, Hash)]
 pub struct AuthorityRound {
     pub authority: AuthorityIndex,
     pub round: RoundNumber,


### PR DESCRIPTION
This PR is addressing the following:

* It is possible the last decided leader to be a `Skip` one. In that case we don't return that at all making the commit rule retry committing again for that round the next time which is not efficient. Instead we are now keep the last "decided" leader to correctly resume the commit rule. We still keep storing though the last "committed" for crash/recovery.
* Simplify the filtering logic on the `try_commit` method and process up to `highest_known_round.saturating_sub(2)` since it would never be possible to draw any meaningful conclusions for them
* report the metrics _after_ the decided leaders that will be committed/skipped have been figured out. That avoids any issues of double counting when we can't commit due to early undecided leaders.