### PR TITLE
[refactor] improve synchronizer and bulk block processing

### DIFF
--- a/mysticeti-core/Cargo.toml
+++ b/mysticeti-core/Cargo.toml
@@ -38,9 +38,9 @@ zeroize = "1.6.0"
 tabled = "0.12.2"
 gettid = "0.1.2"
 crc32fast = "1.3.2"
+itertools = "0.11.0"
 
 [dev-dependencies]
-itertools = "0.11.0"
 reqwest = { workspace = true }
 tracing-test = "0.2.4"
 tempdir = "0.3.7"

--- a/mysticeti-core/src/block_manager.rs
+++ b/mysticeti-core/src/block_manager.rs
@@ -113,6 +113,10 @@ impl BlockManager {
     pub fn missing_blocks(&self) -> &[HashSet<BlockReference>] {
         &self.missing
     }
+
+    pub fn exists_or_pending(&self, id: BlockReference) -> bool {
+        self.block_store.block_exists(id) || self.blocks_pending.contains_key(&id)
+    }
 }
 
 #[cfg(test)]

--- a/mysticeti-core/src/committee.rs
+++ b/mysticeti-core/src/committee.rs
@@ -113,6 +113,11 @@ impl Committee {
         (own_genesis_block, other_blocks)
     }
 
+    pub fn authority_safe(&self, authority_index: AuthorityIndex) -> &Authority {
+        self.authorities
+            .get(authority_index as usize)
+            .unwrap_or_else(|| panic!("Authority with id {} not exists", authority_index))
+    }
     pub fn is_valid(&self, amount: Stake) -> bool {
         amount > self.validity_threshold
     }
@@ -191,17 +196,23 @@ impl Committee {
 pub struct Authority {
     stake: Stake,
     public_key: PublicKey,
+    hostname: String,
 }
 
 impl Authority {
-    pub fn new(stake: Stake, public_key: PublicKey) -> Self {
-        Self { stake, public_key }
+    pub fn new(stake: Stake, public_key: PublicKey, hostname: String) -> Self {
+        Self {
+            stake,
+            public_key,
+            hostname,
+        }
     }
 
     pub fn test_from_stake(stake: Stake) -> Self {
         Self {
             stake,
             public_key: dummy_public_key(),
+            hostname: "".to_string(),
         }
     }
 
@@ -211,6 +222,10 @@ impl Authority {
 
     pub fn public_key(&self) -> &PublicKey {
         &self.public_key
+    }
+
+    pub fn hostname(&self) -> String {
+        self.hostname.clone()
     }
 }
 

--- a/mysticeti-core/src/config.rs
+++ b/mysticeti-core/src/config.rs
@@ -44,6 +44,8 @@ pub struct Parameters {
     pub shutdown_grace_period: Duration,
     pub number_of_leaders: usize,
     pub enable_pipelining: bool,
+    pub enable_cleanup: bool,
+    pub synchronizer_parameters: SynchronizerParameters,
 }
 
 impl Default for Parameters {
@@ -55,11 +57,39 @@ impl Default for Parameters {
             rounds_in_epoch: Self::DEFAULT_ROUNDS_IN_EPOCH,
             shutdown_grace_period: Self::DEFAULT_SHUTDOWN_GRACE_PERIOD,
             number_of_leaders: Self::DEFAULT_NUMBER_OF_LEADERS,
-            enable_pipelining: true,
+            enable_pipelining: false,
+            enable_cleanup: true,
+            synchronizer_parameters: SynchronizerParameters::default(),
         }
     }
 }
 
+// TODO: A central controller will eventually dynamically update these parameters.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SynchronizerParameters {
+    /// The maximum number of helpers per authority.
+    pub maximum_helpers_per_authority: usize,
+    /// The number of blocks to send in a single batch.
+    pub batch_size: usize,
+    /// The sampling precision with which to re-evaluate the sync strategy.
+    pub sample_precision: Duration,
+    /// The interval at which to send stream blocks authored by other nodes.
+    pub stream_interval: Duration,
+    /// Threshold number of missing block from an authority to open a new stream.
+    pub new_stream_threshold: usize,
+}
+
+impl Default for SynchronizerParameters {
+    fn default() -> Self {
+        Self {
+            maximum_helpers_per_authority: 2,
+            batch_size: 100,
+            sample_precision: Duration::from_millis(250),
+            stream_interval: Duration::from_secs(1),
+            new_stream_threshold: 10,
+        }
+    }
+}
 impl Parameters {
     pub const DEFAULT_FILENAME: &'static str = "parameters.yaml";
 

--- a/mysticeti-core/src/core_thread/spawned.rs
+++ b/mysticeti-core/src/core_thread/spawned.rs
@@ -29,6 +29,10 @@ enum CoreThreadCommand {
     Cleanup(oneshot::Sender<()>),
     /// Request missing blocks that need to be synched.
     GetMissing(oneshot::Sender<Vec<HashSet<BlockReference>>>),
+    Processed(
+        Vec<BlockReference>,
+        oneshot::Sender<HashSet<BlockReference>>,
+    ),
 }
 
 impl<H: BlockHandler + 'static, S: SyncerSignals + 'static, C: CommitObserver + 'static>
@@ -92,6 +96,11 @@ impl<H: BlockHandler + 'static, S: SyncerSignals + 'static, C: CommitObserver + 
         receiver.await.expect("core thread is not expected to stop")
     }
 
+    pub async fn processed(&self, refs: Vec<BlockReference>) -> HashSet<BlockReference> {
+        let (sender, receiver) = oneshot::channel();
+        self.send(CoreThreadCommand::Processed(refs, sender)).await;
+        receiver.await.expect("core thread is not expected to stop")
+    }
     async fn send(&self, command: CoreThreadCommand) {
         self.metrics.core_lock_enqueued.inc();
         if self.sender.send(command).await.is_err() {
@@ -123,6 +132,18 @@ impl<H: BlockHandler, S: SyncerSignals, C: CommitObserver> CoreThread<H, S, C> {
                 CoreThreadCommand::GetMissing(sender) => {
                     let missing = self.syncer.core().block_manager().missing_blocks();
                     sender.send(missing.to_vec()).ok();
+                }
+                CoreThreadCommand::Processed(refs, sender) => {
+                    let result = refs
+                        .into_iter()
+                        .filter(|block_id| {
+                            self.syncer
+                                .core()
+                                .block_manager()
+                                .exists_or_pending(*block_id)
+                        })
+                        .collect();
+                    sender.send(result).ok();
                 }
             }
         }

--- a/mysticeti-core/src/metrics.rs
+++ b/mysticeti-core/src/metrics.rs
@@ -79,6 +79,7 @@ pub struct Metrics {
     pub blocks_per_commit_count: HistogramSender<usize>,
     pub sub_dags_per_commit_count: HistogramSender<usize>,
     pub block_commit_latency: HistogramSender<Duration>,
+    pub block_receive_latency: HistogramVec,
 }
 
 pub struct MetricReporter {
@@ -371,6 +372,13 @@ impl Metrics {
             blocks_suspended: register_int_counter_with_registry!(
                 "blocks_suspended",
                 "The number of blocks that got suspended due to missing references",
+                registry
+            ).unwrap(),
+
+            block_receive_latency: register_histogram_vec_with_registry!(
+                "block_receive_latency",
+                "The time it took for a block to reach our node",
+                &["authority", "proc"],
                 registry
             ).unwrap(),
 

--- a/mysticeti-core/src/network.rs
+++ b/mysticeti-core/src/network.rs
@@ -35,6 +35,8 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 pub enum NetworkMessage {
     SubscribeOwnFrom(RoundNumber), // subscribe from round number excluding
     Block(Data<StatementBlock>),
+    // Sending multiple blocks at once
+    Blocks(Vec<Data<StatementBlock>>),
     /// Request a few specific block references (this is not indented for large requests).
     RequestBlocks(Vec<BlockReference>),
     /// Indicate that a requested block is not found.
@@ -51,6 +53,7 @@ pub struct Connection {
     pub peer_id: usize,
     pub sender: mpsc::Sender<NetworkMessage>,
     pub receiver: mpsc::Receiver<NetworkMessage>,
+    pub latency_last_value_receiver: tokio::sync::watch::Receiver<Duration>,
 }
 
 impl Network {
@@ -192,6 +195,7 @@ struct WorkerConnection {
     receiver: mpsc::Receiver<NetworkMessage>,
     peer_id: usize,
     latency_sender: HistogramSender<Duration>,
+    latency_last_value_sender: tokio::sync::watch::Sender<Duration>,
 }
 
 impl Worker {
@@ -281,12 +285,19 @@ impl Worker {
             receiver,
             peer_id,
             latency_sender,
+            latency_last_value_sender,
         } = connection;
         tracing::debug!("Connected to {}", peer_id);
         let (reader, writer) = stream.into_split();
         let (pong_sender, pong_receiver) = mpsc::channel(16);
-        let write_fut =
-            Self::handle_write_stream(writer, receiver, pong_receiver, latency_sender).boxed();
+        let write_fut = Self::handle_write_stream(
+            writer,
+            receiver,
+            pong_receiver,
+            latency_sender,
+            latency_last_value_sender,
+        )
+        .boxed();
         let read_fut = Self::handle_read_stream(reader, sender, pong_sender).boxed();
         let (r, _, _) = select_all([write_fut, read_fut]).await;
         tracing::debug!("Disconnected from {}", peer_id);
@@ -298,6 +309,7 @@ impl Worker {
         mut receiver: mpsc::Receiver<NetworkMessage>,
         mut pong_receiver: mpsc::Receiver<i64>,
         latency_sender: HistogramSender<Duration>,
+        latency_last_value_sender: tokio::sync::watch::Sender<Duration>,
     ) -> io::Result<()> {
         let start = Instant::now();
         let mut ping_deadline = start + PING_INTERVAL;
@@ -341,7 +353,9 @@ impl Worker {
                                 let time = start.elapsed().as_micros() as u64;
                                 match time.checked_sub(our_ping) {
                                     Some(delay) => {
-                                        latency_sender.observe(Duration::from_micros(delay));
+                                        let d = Duration::from_micros(delay);
+                                        latency_sender.observe(d);
+                                        latency_last_value_sender.send(d).ok();
                                     },
                                     None => {
                                         tracing::warn!("Invalid ping: {ping}, greater then current time {time}");
@@ -415,17 +429,22 @@ impl Worker {
     async fn make_connection(&self) -> Option<WorkerConnection> {
         let (network_in_sender, network_in_receiver) = mpsc::channel(16);
         let (network_out_sender, network_out_receiver) = mpsc::channel(16);
+        let (latency_last_value_sender, latency_last_value_receiver) =
+            tokio::sync::watch::channel(Duration::from_millis(0));
         let connection = Connection {
             peer_id: self.peer_id,
             sender: network_out_sender,
             receiver: network_in_receiver,
+            latency_last_value_receiver,
         };
+
         self.connection_sender.send(connection).await.ok()?;
         Some(WorkerConnection {
             sender: network_in_sender,
             receiver: network_out_receiver,
             peer_id: self.peer_id,
             latency_sender: self.latency_sender.clone(),
+            latency_last_value_sender,
         })
     }
 }

--- a/mysticeti-core/src/simulated_network.rs
+++ b/mysticeti-core/src/simulated_network.rs
@@ -55,15 +55,19 @@ impl SimulatedNetwork {
     pub async fn connect(&self, a: usize, b: usize) {
         let (a_sender, a_receiver) = Self::latency_channel();
         let (b_sender, b_receiver) = Self::latency_channel();
+        let (_al_sender, al_receiver) = tokio::sync::watch::channel(Duration::from_secs(0));
+        let (_bl_sender, bl_receiver) = tokio::sync::watch::channel(Duration::from_secs(0));
         let a_connection = Connection {
             peer_id: b,
             sender: b_sender,
             receiver: a_receiver,
+            latency_last_value_receiver: al_receiver,
         };
         let b_connection = Connection {
             peer_id: a,
             sender: a_sender,
             receiver: b_receiver,
+            latency_last_value_receiver: bl_receiver,
         };
         let a = &self.senders[a];
         let b = &self.senders[b];

--- a/mysticeti-core/src/test_util.rs
+++ b/mysticeti-core/src/test_util.rs
@@ -206,6 +206,7 @@ pub fn simulated_network_syncers_with_epoch_duration(
         committee_and_cores_epoch_duration(n, rounds_in_epoch);
     let (simulated_network, networks) = SimulatedNetwork::new(&committee);
     let mut network_syncers = vec![];
+    let parameters = Parameters::default();
     for ((network, core), commit_observer) in networks.into_iter().zip(cores).zip(commit_observers)
     {
         let node_context = OverrideNodeContext::enter(Some(core.authority()));
@@ -217,6 +218,9 @@ pub fn simulated_network_syncers_with_epoch_duration(
             Parameters::DEFAULT_SHUTDOWN_GRACE_PERIOD,
             AcceptAllBlockVerifier,
             test_metrics(),
+            parameters.leader_timeout,
+            parameters.synchronizer_parameters.clone(),
+            parameters.enable_cleanup,
         );
         drop(node_context);
         network_syncers.push(network_syncer);
@@ -236,6 +240,7 @@ pub async fn network_syncers_with_epoch_duration(
     let metrics: Vec<_> = cores.iter().map(|c| c.metrics.clone()).collect();
     let (networks, _) = networks_and_addresses(&metrics).await;
     let mut network_syncers = vec![];
+    let parameters = Parameters::default();
     for ((network, core), commit_observer) in networks.into_iter().zip(cores).zip(commit_observers)
     {
         let network_syncer = NetworkSyncer::start(
@@ -246,6 +251,9 @@ pub async fn network_syncers_with_epoch_duration(
             Parameters::DEFAULT_SHUTDOWN_GRACE_PERIOD,
             AcceptAllBlockVerifier,
             test_metrics(),
+            parameters.leader_timeout,
+            parameters.synchronizer_parameters.clone(),
+            parameters.enable_cleanup,
         );
         network_syncers.push(network_syncer);
     }

--- a/mysticeti-core/src/validator.rs
+++ b/mysticeti-core/src/validator.rs
@@ -263,6 +263,9 @@ impl<B: BlockHandler + 'static, C: CommitObserver + 'static> Validator<B, C> {
             parameters.shutdown_grace_period(),
             block_verifier,
             metrics,
+            parameters.leader_timeout,
+            parameters.synchronizer_parameters.clone(),
+            parameters.enable_cleanup,
         );
 
         tracing::info!("Validator {authority} listening on {network_address}");


### PR DESCRIPTION
This PR is:

* making the synchronzer continuously sending blocks to peers and not attempt send only when a new block is out. 
* sample peers based on latency to ensure that lower latency peers are prioritised (there might be some exceptions to that)
* make the send operations on the block disseminator non blocking - so we avoid clogging the network loops
* send multiple blocks at once and process them in bulk and pre-check if they have been already processed so we avoid any penalties from verification etc.