### PR TITLE
[feat] request missing blocks directly from the proposer of a block.

### DIFF
--- a/mysticeti-core/src/block_manager.rs
+++ b/mysticeti-core/src/block_manager.rs
@@ -42,7 +42,7 @@ impl BlockManager {
     /// Attempts to process (accept) the provided blocks and stores them only when the causal history
     /// is already present. If a block can't be processed, then it is parked in the `blocks_pending` map
     /// and any missing references are recorded in the `block_references_waiting` and in the `missing` vector.
-    /// The method returns a tuple where the newly accepted/processed blocks are returned and the missing references
+    /// The method returns a tuple where are returned (1) the newly accepted/processed blocks (2) the missing references
     /// of the provided blocks. Keep in mind that the missing references are returned only the first one for a specific
     /// provided block. If we attempt to add the same block again, then its missing references won't be returned again.
     pub fn add_blocks(

--- a/mysticeti-core/src/core_thread/simulated.rs
+++ b/mysticeti-core/src/core_thread/simulated.rs
@@ -32,8 +32,8 @@ impl<H: BlockHandler + 'static, S: SyncerSignals + 'static, C: CommitObserver + 
         &self,
         blocks: Vec<Data<StatementBlock>>,
         connected_authorities: AuthoritySet,
-    ) {
-        self.syncer.lock().add_blocks(blocks, connected_authorities);
+    ) -> Vec<BlockReference> {
+        self.syncer.lock().add_blocks(blocks, connected_authorities)
     }
 
     pub async fn force_new_block(&self, round: RoundNumber, connected_authorities: AuthoritySet) {

--- a/mysticeti-core/src/net_sync.rs
+++ b/mysticeti-core/src/net_sync.rs
@@ -9,7 +9,7 @@ use crate::runtime::Handle;
 use crate::runtime::{self, timestamp_utc};
 use crate::runtime::{JoinError, JoinHandle};
 use crate::syncer::{Signals, Syncer};
-use crate::types::{AuthorityIndex, StatementBlock};
+use crate::types::{AuthorityIndex, BlockReference, StatementBlock};
 use crate::types::{AuthoritySet, RoundNumber};
 use crate::wal::WalSyncer;
 use crate::{block_handler::BlockHandler, metrics::Metrics};
@@ -267,18 +267,14 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
                     disseminator.disseminate_own_blocks(round).await
                 }
                 NetworkMessage::Blocks(blocks) => {
-                    if Self::process_blocks(&inner, &block_verifier, &metrics, blocks)
-                        .await
-                        .is_err()
+                    if let Ok(missing_blocks) =
+                        Self::process_blocks(&inner, &block_verifier, &metrics, blocks).await
                     {
-                        break;
-                    }
-                }
-                NetworkMessage::Block(block) => {
-                    if Self::process_blocks(&inner, &block_verifier, &metrics, vec![block])
-                        .await
-                        .is_err()
-                    {
+                        // we only want to request missing blocks when a validator is sending us their block
+                        // proposals, and not during a bulk catchup via our request (RequestBlocks) to avoid
+                        // overwhelming the peer.
+                        Self::request_missing_blocks(missing_blocks, &connection.sender);
+                    } else {
                         break;
                     }
                 }
@@ -291,6 +287,14 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
                         .send_blocks(authority, references)
                         .await
                         .is_none()
+                    {
+                        break;
+                    }
+                }
+                NetworkMessage::RequestBlocksResponse(blocks) => {
+                    if Self::process_blocks(&inner, &block_verifier, &metrics, blocks)
+                        .await
+                        .is_err()
                     {
                         break;
                     }
@@ -312,9 +316,9 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
         block_verifier: &Arc<impl BlockVerifier>,
         metrics: &Arc<Metrics>,
         blocks: Vec<Data<StatementBlock>>,
-    ) -> Result<(), eyre::Report> {
+    ) -> Result<Vec<BlockReference>, eyre::Report> {
         if blocks.is_empty() {
-            return Ok(());
+            return Ok(vec![]);
         }
 
         let now = timestamp_utc();
@@ -372,13 +376,22 @@ impl<H: BlockHandler + 'static, C: CommitObserver + 'static> NetworkSyncer<H, C>
 
         if !to_process.is_empty() {
             let connected_authorities = inner.connected_authorities.lock().authorities.clone();
-            inner
+            return Ok(inner
                 .syncer
                 .add_blocks(to_process, connected_authorities)
-                .await;
+                .await);
         }
 
-        Ok(())
+        Ok(vec![])
+    }
+
+    fn request_missing_blocks(
+        missing_blocks: Vec<BlockReference>,
+        sender: &mpsc::Sender<NetworkMessage>,
+    ) {
+        if let Ok(permit) = sender.try_reserve() {
+            permit.send(NetworkMessage::RequestBlocks(missing_blocks))
+        }
     }
 
     async fn leader_timeout_task(

--- a/mysticeti-core/src/network.rs
+++ b/mysticeti-core/src/network.rs
@@ -34,11 +34,12 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NetworkMessage {
     SubscribeOwnFrom(RoundNumber), // subscribe from round number excluding
-    Block(Data<StatementBlock>),
-    // Sending multiple blocks at once
+    /// Sending multiple blocks at once
     Blocks(Vec<Data<StatementBlock>>),
     /// Request a few specific block references (this is not indented for large requests).
     RequestBlocks(Vec<BlockReference>),
+    /// The response to the request blocks
+    RequestBlocksResponse(Vec<Data<StatementBlock>>),
     /// Indicate that a requested block is not found.
     BlockNotFound(Vec<BlockReference>),
 }

--- a/mysticeti-core/src/synchronizer.rs
+++ b/mysticeti-core/src/synchronizer.rs
@@ -189,9 +189,9 @@ where
             let blocks = inner
                 .block_store
                 .get_others_blocks(round, author, batch_size);
-            for block in blocks {
-                round = block.round();
-                to.send(NetworkMessage::Block(block)).await.ok()?;
+            if !blocks.is_empty() {
+                round = blocks.last().unwrap().round();
+                to.send(NetworkMessage::Blocks(blocks)).await.ok()?;
             }
             sleep(stream_interval).await;
         }

--- a/mysticeti-core/src/synchronizer.rs
+++ b/mysticeti-core/src/synchronizer.rs
@@ -189,8 +189,8 @@ where
             let blocks = inner
                 .block_store
                 .get_others_blocks(round, author, batch_size);
-            if !blocks.is_empty() {
-                round = blocks.last().unwrap().round();
+            if let Some(last_block) = blocks.last() {
+                round = last_block.round();
                 to.send(NetworkMessage::Blocks(blocks)).await.ok()?;
             }
             sleep(stream_interval).await;


### PR DESCRIPTION
Request missing references of a proposed block directly from it's author. The block_manager is refactored to keep track of the missing references and return those the very first time they are tracked. Attention should be paid on the fact that the missing references are requested back from the peer only for the proposed blocks , not for the ones requested via the synchronizer . That is done to avoid overwhelming the peers.